### PR TITLE
Add Rampage mode to shooting range

### DIFF
--- a/addons/shootingrange/CfgVehicles.hpp
+++ b/addons/shootingrange/CfgVehicles.hpp
@@ -51,6 +51,10 @@ class CfgVehicles {
                         name = CSTRING(Trigger);
                         value = 4;
                     };
+                    class Rampage {
+                        name = CSTRING(Rampage);
+                        value = 5;
+                    };
                 };
             };
             class Durations {

--- a/addons/shootingrange/functions/fnc_create.sqf
+++ b/addons/shootingrange/functions/fnc_create.sqf
@@ -213,7 +213,7 @@ _countdownTimes sort true;
 
     [_x, 0, ["ACE_MainActions", QGVAR(Range), QGVAR(RangeConfig)], _actionConfigTargetAmount] call ACE_Interact_Menu_fnc_addActionToObject;
 
-    if (_mode < 4) then {
+    if (_mode != 4) then {
         private _actionConfigPauseDuration = [
             QGVAR(RangeConfigPauseDuration),
             localize LSTRING(PauseDuration),
@@ -239,7 +239,7 @@ _countdownTimes sort true;
 
     [_x, 0, ["ACE_MainActions", QGVAR(Range), QGVAR(RangeConfig)], _actionConfigCountdownTime] call ACE_Interact_Menu_fnc_addActionToObject;
 
-    if (_mode < 4) then {
+    if (_mode != 4) then {
         private _actionConfigMode = [
             QGVAR(RangeConfigMode),
             localize LSTRING(Mode),
@@ -261,7 +261,7 @@ _countdownTimes sort true;
         ] call ACE_Interact_Menu_fnc_createAction;
 
         private _actionConfigModeHitTimeLimited = [
-            QGVAR(RangeConfigModeHit),
+            QGVAR(RangeConfigModeHitTimeLimited),
             localize LSTRING(HitTimeLimit),
             "",
             {(_this select 2) call FUNC(setConfigMode)},
@@ -271,7 +271,7 @@ _countdownTimes sort true;
         ] call ACE_Interact_Menu_fnc_createAction;
 
         private _actionConfigModeHitTargetLimited = [
-            QGVAR(RangeConfigModeHit),
+            QGVAR(RangeConfigModeHitTargetLimited),
             localize LSTRING(HitTargetLimit),
             "",
             {(_this select 2) call FUNC(setConfigMode)},
@@ -280,10 +280,21 @@ _countdownTimes sort true;
             [_name, _x, _controllers, 3, _targets]
         ] call ACE_Interact_Menu_fnc_createAction;
 
+        private _actionConfigModeRampage = [
+            QGVAR(RangeConfigModeRampage),
+            localize LSTRING(Rampage),
+            "",
+            {(_this select 2) call FUNC(setConfigMode)},
+            {true},
+            {},
+            [_name, _x, _controllers, 5, _targets]
+        ] call ACE_Interact_Menu_fnc_createAction;
+
         [_x, 0, ["ACE_MainActions", QGVAR(Range), QGVAR(RangeConfig)], _actionConfigMode] call ACE_Interact_Menu_fnc_addActionToObject;
         [_x, 0, ["ACE_MainActions", QGVAR(Range), QGVAR(RangeConfig), QGVAR(RangeConfigMode)], _actionConfigModeTime] call ACE_Interact_Menu_fnc_addActionToObject;
         [_x, 0, ["ACE_MainActions", QGVAR(Range), QGVAR(RangeConfig), QGVAR(RangeConfigMode)], _actionConfigModeHitTimeLimited] call ACE_Interact_Menu_fnc_addActionToObject;
         [_x, 0, ["ACE_MainActions", QGVAR(Range), QGVAR(RangeConfig), QGVAR(RangeConfigMode)], _actionConfigModeHitTargetLimited] call ACE_Interact_Menu_fnc_addActionToObject;
+        [_x, 0, ["ACE_MainActions", QGVAR(Range), QGVAR(RangeConfig), QGVAR(RangeConfigMode)], _actionConfigModeRampage] call ACE_Interact_Menu_fnc_addActionToObject;
     };
 } forEach _controllers;
 

--- a/addons/shootingrange/functions/fnc_popupPFH.sqf
+++ b/addons/shootingrange/functions/fnc_popupPFH.sqf
@@ -12,7 +12,7 @@
  *   5: Controller <OBJECT>
  *   6: Controllers <ARRAY>
  *   7: Name <STRING>
- *   8: Mode (1 = Time, 2 = Hit (Time Limited), 3 = Hit (Target Limited), 4 = Trigger) <NUMBER>
+ *   8: Mode (1 = Time, 2 = Hit (Time Limited), 3 = Hit (Target Limited), 4 = Trigger, 5 = Rampage) <NUMBER>
  *   9: Triggers <ARRAY>
  * 1: Per-Frame Handler ID <NUMBER>
  *
@@ -37,7 +37,7 @@ if !(_controller getVariable [QGVAR(running), false]) exitWith {
 private _currentTime = diag_tickTime;
 
 // Remove when time limit (duration) reached - success
-if (_mode in [1, 2] && {_currentTime >= _timeStart + _duration}) exitWith {
+if (_mode in [1, 2, 5] && {_currentTime >= _timeStart + _duration}) exitWith {
     [_idPFH, _controller, _controllers, _name, _targets, _mode, true, GVAR(targetNumber), GVAR(maxScore)] call FUNC(popupPFHexit);
 };
 

--- a/addons/shootingrange/functions/fnc_popupPFHexit.sqf
+++ b/addons/shootingrange/functions/fnc_popupPFHexit.sqf
@@ -45,20 +45,19 @@ GVAR(targetUp) = nil;
 
 // Remove Fired EH if needed
 if (_mode > 1) then {
-    ACE_player removeEventHandler ["Fired", GVAR(firedEHid)];
-    GVAR(firedEHid) = nil;
+    if (_mode < 5) then {
+        ACE_player removeEventHandler ["Fired", GVAR(firedEHid)];
+        GVAR(firedEHid) = nil;
+    };
 
-    if (_mode > 2) then {
+    if (_mode == 4) then {
+        {
+            _x enableSimulation false;
+        } forEach _triggers;
+
+        GVAR(targetGroup) = nil;
+        GVAR(targetGroupIndex) = nil;
         GVAR(timeStartCountdown) = nil;
-
-        if (_mode == 4) then {
-            {
-                _x enableSimulation false;
-            } forEach _triggers;
-
-            GVAR(targetGroup) = nil;
-            GVAR(targetGroupIndex) = nil;
-        };
     };
 } else {
     GVAR(lastPauseTime) = nil;

--- a/addons/shootingrange/functions/fnc_stop.sqf
+++ b/addons/shootingrange/functions/fnc_stop.sqf
@@ -47,7 +47,8 @@ if (_success) then {
         _scorePercentage = round (_score / _maxScore * 100);
     };
 
-    private _text = format ["%1%2 %3<br/><br/>%4: %5%6 (%7/%8)", localize LSTRING(Range), _name, localize LSTRING(Finished), localize LSTRING(Accuracy), _scorePercentage, "%", _score, _maxScore];
+    private _ratingType = [localize LSTRING(Accuracy), localize LSTRING(TargetsHit)] select (_mode == 5);
+    private _text = format ["%1%2 %3<br/><br/>%4: %5%6 (%7/%8)", localize LSTRING(Range), _name, localize LSTRING(Finished), _ratingType, _scorePercentage, "%", _score, _maxScore];
     private _size = 3;
 
     if (_timeElapsed > 0) then {

--- a/addons/shootingrange/script_component.hpp
+++ b/addons/shootingrange/script_component.hpp
@@ -1,8 +1,8 @@
 #define COMPONENT shootingrange
 #include "\x\tac\addons\main\script_mod.hpp"
 
-#define DEBUG_MODE_FULL
-#define DISABLE_COMPILE_CACHE
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
 // #define CBA_DEBUG_SYNCHRONOUS
 // #define ENABLE_PERFORMANCE_COUNTERS
 

--- a/addons/shootingrange/script_component.hpp
+++ b/addons/shootingrange/script_component.hpp
@@ -1,8 +1,8 @@
 #define COMPONENT shootingrange
 #include "\x\tac\addons\main\script_mod.hpp"
 
-// #define DEBUG_MODE_FULL
-// #define DISABLE_COMPILE_CACHE
+#define DEBUG_MODE_FULL
+#define DISABLE_COMPILE_CACHE
 // #define CBA_DEBUG_SYNCHRONOUS
 // #define ENABLE_PERFORMANCE_COUNTERS
 

--- a/addons/shootingrange/stringtable.xml
+++ b/addons/shootingrange/stringtable.xml
@@ -38,7 +38,7 @@
             <German>Modus</German>
         </Key>
         <Key ID="STR_TAC_ShootingRange_ModeDesc">
-            <English>Time and Hit require Duration, Trigger requires Trigger Markers. Default: Time</English>
+            <English>Time and Hit require Duration, Trigger requires Trigger Markers. Default: Timed</English>
             <German>Zeit- und Treffermodus benötigen Zeit. Auslösermodus benötigt Auslöser-Markierungen. Standard: Zeitmodus</German>
         </Key>
         <Key ID="STR_TAC_ShootingRange_Durations">
@@ -46,16 +46,14 @@
             <German>Laufzeiten</German>
         </Key>
         <Key ID="STR_TAC_ShootingRange_DurationsDesc">
-            <English>List of available shooting durations in seconds, separated by commas. Only used in Time and Hit (Time Limited) Modes. Default: 0, 30, 60, 150, 300</English>
-            <German>Liste der möglichen Schießstand-Laufzeiten in Sekunden. Durch Kommas trennen. Wird nur im Zeit- und Treffermodus (Zeitlimit) genutzt. Standard: 0, 30, 60, 150, 300</German>
+            <English>List of available shooting durations in seconds, separated by commas. Only used in Timed, Hit (Time Limited) and Rampage Modes. Default: 0, 30, 60, 150, 300</English>
         </Key>
         <Key ID="STR_TAC_ShootingRange_DefaultDuration">
             <English>Default Duration</English>
             <German>Standardzeit</German>
         </Key>
         <Key ID="STR_TAC_ShootingRange_DefaultDurationDesc">
-            <English>Default shooting duration in seconds. Only used in Time and Hit (Time Limited) Modes. Default: 60</English>
-            <German>Standardzeit in Sekunden. Wird nur im Zeit- und Treffermodus (Zeitlimit) genutzt. Standard: 60</German>
+            <English>Default shooting duration in seconds. Only used in Timed, Hit (Time Limited) and Rampage Modes. Default: 60</English>
         </Key>
         <Key ID="STR_TAC_ShootingRange_TargetAmounts">
             <English>Target Amounts</English>
@@ -132,6 +130,9 @@
         <Key ID="STR_TAC_ShootingRange_Trigger">
             <English>Trigger</English>
             <German>Auslöser</German>
+        </Key>
+        <Key ID="STR_TAC_ShootingRange_Rampage">
+            <English>Rampage</English>
         </Key>
         <Key ID="STR_TAC_ShootingRange_Start">
             <English>Start</English>
@@ -216,6 +217,9 @@
         <Key ID="STR_TAC_ShootingRange_TargetHitBy">
             <English>Target hit by</English>
             <German>Ziel getroffen von</German>
+        </Key>
+        <Key ID="STR_TAC_ShootingRange_TargetsHit">
+            <English>Targets Hit</English>
         </Key>
     </Package>
 </Project>


### PR DESCRIPTION
Close #118 

Rampage mode pops up all targets and displays targets hit out of all targets in specified time limit.

- [x] Disable debug