### PR TITLE
Add bodybag inventory transferring

### DIFF
--- a/addons/bodybag/$PBOPREFIX$
+++ b/addons/bodybag/$PBOPREFIX$
@@ -1,0 +1,1 @@
+x\tac\addons\bodybag

--- a/addons/bodybag/CfgEventHandlers.hpp
+++ b/addons/bodybag/CfgEventHandlers.hpp
@@ -1,0 +1,25 @@
+class Extended_PreStart_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preStart));
+    };
+};
+
+class Extended_PreInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_preInit));
+    };
+};
+
+class Extended_PostInit_EventHandlers {
+    class ADDON {
+        init = QUOTE(call COMPILE_FILE(XEH_postInit));
+    };
+};
+
+class Extended_Killed_EventHandlers {
+    class CAManBase {
+        class ADDON {
+            killed = QUOTE(_this call FUNC(saveDroppedWeapons));
+        };
+    };
+};

--- a/addons/bodybag/CfgVehicles.hpp
+++ b/addons/bodybag/CfgVehicles.hpp
@@ -1,0 +1,8 @@
+class CfgVehicles {
+    class MapBoard_altis_F;
+    class ACE_bodyBagObject: MapBoard_altis_F {
+        transportMaxWeapons = 1;
+        transportMaxMagazines = 1;
+        transportMaxItems = 1;
+    };
+};

--- a/addons/bodybag/README.md
+++ b/addons/bodybag/README.md
@@ -1,0 +1,7 @@
+# About
+
+Adds inventory transferring from dead body to body bag object upon placing it into a body bag.
+
+### Authors
+
+- [Jonpas](http://github.com/jonpas)

--- a/addons/bodybag/XEH_PREP.hpp
+++ b/addons/bodybag/XEH_PREP.hpp
@@ -1,0 +1,3 @@
+PREP(moveInventory);
+PREP(placeDroppedWeapons);
+PREP(saveDroppedWeapons);

--- a/addons/bodybag/XEH_postInit.sqf
+++ b/addons/bodybag/XEH_postInit.sqf
@@ -1,0 +1,12 @@
+#include "script_component.hpp"
+
+// Exit on clients and non-hosts
+if (hasInterface && !isServer) exitWith {};
+
+["placedInBodyBag", {
+    // Move all inventory from body to bodybag
+    _this call FUNC(moveInventory);
+
+    // Replace dropped primary weapon and launcher
+    _this call FUNC(placeDroppedWeapons);
+}] call ACE_Common_fnc_addEventHandler;

--- a/addons/bodybag/XEH_postInit.sqf
+++ b/addons/bodybag/XEH_postInit.sqf
@@ -1,7 +1,7 @@
 #include "script_component.hpp"
 
 // Exit on clients and non-hosts
-if (hasInterface && !isServer) exitWith {};
+if (!isServer) exitWith {};
 
 ["placedInBodyBag", {
     // Move all inventory from body to bodybag

--- a/addons/bodybag/XEH_preInit.sqf
+++ b/addons/bodybag/XEH_preInit.sqf
@@ -1,0 +1,7 @@
+#include "script_component.hpp"
+
+ADDON = false;
+
+#include "XEH_PREP.hpp"
+
+ADDON = true;

--- a/addons/bodybag/XEH_preStart.sqf
+++ b/addons/bodybag/XEH_preStart.sqf
@@ -1,0 +1,3 @@
+#include "script_component.hpp"
+
+#include "XEH_PREP.hpp"

--- a/addons/bodybag/config.cpp
+++ b/addons/bodybag/config.cpp
@@ -1,0 +1,16 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"tac_main", "ace_medical"};
+        author[]= {"Jonpas"};
+        authorUrl = "https://github.com/jonpas";
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgEventHandlers.hpp"
+#include "CfgVehicles.hpp"

--- a/addons/bodybag/functions/fnc_moveInventory.sqf
+++ b/addons/bodybag/functions/fnc_moveInventory.sqf
@@ -1,0 +1,55 @@
+/*
+ * Author: Jonpas
+ * Puts killed unit's inventory into the body bag.
+ *
+ * Arguments:
+ * 0: Killed Unit <OBJECT>
+ * 1: Body Bag <OBJECT>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [killed, bodybag] call tac_bodybag_fnc_moveInventory
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+params ["_unit", "_bodybag"];
+
+private _items = [];
+private _weapons = [];
+private _magazines = [];
+
+_items pushBack (headgear _unit);
+_items pushBack (goggles _unit);
+_items pushBack (uniform _unit);
+_items append (uniformItems _unit);
+_items pushBack (vest _unit);
+_items append (vestItems _unit);
+_items append (backpackItems _unit);
+_weapons pushBack (handgunWeapon _unit);
+_items append (handgunItems _unit);
+_magazines append (handgunMagazine _unit);
+_items append (assignedItems _unit);
+_weapons pushBack (binocular _unit);
+_magazines pushBack ([_unit] call ACE_Common_fnc_binocularMagazine);
+
+_items = _items select {_x != ""};
+_weapons = _weapons select {_x != ""};
+_magazines = _magazines select {_x != ""};
+
+TRACE_3("Body Inventory",_items,_weapons,_magazines);
+
+{
+    _bodybag addItemCargoGlobal [_x, 1];
+} forEach _items;
+{
+    _bodybag addWeaponCargoGlobal [_x, 1];
+} forEach _weapons;
+{
+    _bodybag addMagazineCargoGlobal [_x, 1];
+} forEach _magazines;
+
+_bodybag addBackpackCargoGlobal [backpack _unit, 1];

--- a/addons/bodybag/functions/fnc_placeDroppedWeapons.sqf
+++ b/addons/bodybag/functions/fnc_placeDroppedWeapons.sqf
@@ -1,0 +1,25 @@
+/*
+ * Author: Jonpas
+ * Places dropped weapons on the ground. They are removed when body is removed.
+ *
+ * Arguments:
+ * 0: Killed Unit <OBJECT>
+ * 1: Body Bag <OBJECT>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [killed, bodybag] call tac_bodybag_fnc_placeDroppedWeapons
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+params ["_unit", "_bodybag"];
+
+private _droppedWeapons = _unit getVariable [QGVAR(droppedWeapons), []];
+private _weaponHolder = createVehicle ["WeaponHolderSimulated", _bodybag, [], 0, "NONE"];
+{
+    _weaponHolder addWeaponCargoGlobal [_x, 1];
+} forEach _droppedWeapons;

--- a/addons/bodybag/functions/fnc_placeDroppedWeapons.sqf
+++ b/addons/bodybag/functions/fnc_placeDroppedWeapons.sqf
@@ -28,9 +28,10 @@ private _weaponHolder = createVehicle ["WeaponHolderSimulated", _bodybag, [], 0,
     _weaponHolder addWeaponCargoGlobal [_x, 1];
 } forEach _droppedWeapons;
 
+// Move weapons to body bag position next frame for the body bag handling to be finished
 [{
     params ["_weaponHolder", "_bodybag"];
     _weaponHolder setPosASL (getPosASL _bodybag);
 }, [_weaponHolder, _bodybag]] call ACE_Common_fnc_execNextFrame;
 
-TRACE_4("Weapon Holder",_weaponHolder,getPosASL _weaponHolder,_bodybag,getPosASL _bodybag);
+TRACE_4("Weapons Position",_weaponHolder,getPosASL _weaponHolder,_bodybag,getPosASL _bodybag);

--- a/addons/bodybag/functions/fnc_placeDroppedWeapons.sqf
+++ b/addons/bodybag/functions/fnc_placeDroppedWeapons.sqf
@@ -19,7 +19,18 @@
 params ["_unit", "_bodybag"];
 
 private _droppedWeapons = _unit getVariable [QGVAR(droppedWeapons), []];
-private _weaponHolder = createVehicle ["WeaponHolderSimulated", _bodybag, [], 0, "NONE"];
+TRACE_1("Place Weapons",_droppedWeapons);
+
+if (_droppedWeapons isEqualTo []) exitWith {};
+
+private _weaponHolder = createVehicle ["WeaponHolderSimulated", _bodybag, [], 0, "CAN_COLLIDE"];
 {
     _weaponHolder addWeaponCargoGlobal [_x, 1];
 } forEach _droppedWeapons;
+
+[{
+    params ["_weaponHolder", "_bodybag"];
+    _weaponHolder setPosASL (getPosASL _bodybag);
+}, [_weaponHolder, _bodybag]] call ACE_Common_fnc_execNextFrame;
+
+TRACE_4("Weapon Holder",_weaponHolder,getPosASL _weaponHolder,_bodybag,getPosASL _bodybag);

--- a/addons/bodybag/functions/fnc_saveDroppedWeapons.sqf
+++ b/addons/bodybag/functions/fnc_saveDroppedWeapons.sqf
@@ -1,0 +1,25 @@
+/*
+ * Author: Jonpas
+ * Saves dropped weapons to a variable on the unit. Workaround for restoring dropped weapons which get deleted with deleteVehicle.
+ *
+ * Arguments:
+ * 0: Killed Unit <OBJECT>
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * [killed, killer] call tac_bodybag_fnc_saveDroppedWeapons
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+params ["_unit"];
+
+private _droppedPrimary = primaryWeapon _unit;
+private _droppedSecondary = secondaryWeapon _unit;
+
+TRACE_2("Dropped Weapons",_droppedPrimary,_droppedSecondary);
+
+_unit setVariable [QGVAR(droppedWeapons), [_droppedPrimary, _droppedSecondary], false];

--- a/addons/bodybag/functions/fnc_saveDroppedWeapons.sqf
+++ b/addons/bodybag/functions/fnc_saveDroppedWeapons.sqf
@@ -9,7 +9,7 @@
  * None
  *
  * Example:
- * [killed, killer] call tac_bodybag_fnc_saveDroppedWeapons
+ * [killed] call tac_bodybag_fnc_saveDroppedWeapons
  *
  * Public: No
  */
@@ -20,6 +20,8 @@ params ["_unit"];
 private _droppedPrimary = primaryWeapon _unit;
 private _droppedSecondary = secondaryWeapon _unit;
 
-TRACE_2("Dropped Weapons",_droppedPrimary,_droppedSecondary);
+private _weapons = [_droppedPrimary, _droppedSecondary] select {_x != ""};
 
-_unit setVariable [QGVAR(droppedWeapons), [_droppedPrimary, _droppedSecondary], false];
+_unit setVariable [QGVAR(droppedWeapons), _weapons, true];
+
+TRACE_3("Dropped Weapons",_droppedPrimary,_droppedSecondary,_weapons);

--- a/addons/bodybag/functions/script_component.hpp
+++ b/addons/bodybag/functions/script_component.hpp
@@ -1,0 +1,1 @@
+#include "\x\tac\addons\bodybag\script_component.hpp"

--- a/addons/bodybag/script_component.hpp
+++ b/addons/bodybag/script_component.hpp
@@ -1,0 +1,17 @@
+#define COMPONENT bodybag
+#include "\x\tac\addons\main\script_mod.hpp"
+
+#define DEBUG_MODE_FULL
+#define DISABLE_COMPILE_CACHE
+// #define CBA_DEBUG_SYNCHRONOUS
+// #define ENABLE_PERFORMANCE_COUNTERS
+
+#ifdef DEBUG_ENABLED_BODYBAG
+    #define DEBUG_MODE_FULL
+#endif
+
+#ifdef DEBUG_SETTINGS_BODYBAG
+    #define DEBUG_SETTINGS DEBUG_SETTINGS_BODYBAG
+#endif
+
+#include "\x\tac\addons\main\script_macros.hpp"

--- a/addons/bodybag/script_component.hpp
+++ b/addons/bodybag/script_component.hpp
@@ -1,8 +1,8 @@
 #define COMPONENT bodybag
 #include "\x\tac\addons\main\script_mod.hpp"
 
-#define DEBUG_MODE_FULL
-#define DISABLE_COMPILE_CACHE
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
 // #define CBA_DEBUG_SYNCHRONOUS
 // #define ENABLE_PERFORMANCE_COUNTERS
 


### PR DESCRIPTION
**When merged this pull request will:**
- Adds body bag inventory transferring - Closes #89 
- Adds inventory to body bag with only 1 unit of space (`addXCargo` commands ignore available space and body bags can't be used as transport boxes)
- Moves all inventory from dead body being placed into a body bag into the body bag's inventory
- Replaces dropped primary weapon and launcher on the ground near the body bag (`deleteVehicle` removes it, but there is no way to get the reference to it from the dead body)