### PR TITLE
Add sound effects to shooting range

### DIFF
--- a/addons/shootingrange/CfgAnimationSourceSounds.hpp
+++ b/addons/shootingrange/CfgAnimationSourceSounds.hpp
@@ -1,0 +1,34 @@
+class CfgAnimationSourceSounds {
+    class GVAR(TargetLargeSound) {
+        class PopUp {
+            loop = 0;
+            sound0[] = {"a3\missions_f_beta\data\sounds\firing_drills\target_pop-up_large.wss", 5, 1, 25};
+            sound[] = {"sound0", 1};
+            terminate = 0;
+            trigger = "phase factor [0.01, 0.01]";
+        };
+        class PopDown {
+            loop = 0;
+            sound0[] = {"a3\missions_f_beta\data\sounds\firing_drills\target_pop-down_large.wss", 5, 1, 25};
+            sound[] = {"sound0", 1};
+            terminate = 0;
+            trigger = "phase factor [0.99, 0.99]";
+        };
+    };
+    class GVAR(TargetSmallSound) {
+        class PopUp {
+            loop = 0;
+            sound0[] = {"a3\missions_f_beta\data\sounds\firing_drills\target_pop-up_small.wss", 1, 1, 25};
+            sound[] = {"sound0", 1};
+            terminate = 0;
+            trigger = "phase factor [0.01, 0.01]";
+        };
+        class PopDown {
+            loop = 0;
+            sound0[] = {"a3\missions_f_beta\data\sounds\firing_drills\target_pop-down_small.wss", 1, 1, 25};
+            sound[] = {"sound0", 1};
+            terminate = 0;
+            trigger = "phase factor [0.99, 0.99]";
+        };
+    };
+};

--- a/addons/shootingrange/CfgVehicles.hpp
+++ b/addons/shootingrange/CfgVehicles.hpp
@@ -116,4 +116,22 @@ class CfgVehicles {
             description = CSTRING(ModuleDesc);
         };
     };
+
+
+    class TargetBase;
+    class TargetP_Inf_F: TargetBase {
+        class AnimationSources {
+            class Terc {
+                sound = QGVAR(TargetLargeSound);
+            };
+        };
+    };
+
+    class Land_Target_Oval_F: TargetBase {
+        class AnimationSources {
+            class Left_Rotate {
+                sound = QGVAR(TargetSmallSound);
+            };
+        };
+    };
 };

--- a/addons/shootingrange/config.cpp
+++ b/addons/shootingrange/config.cpp
@@ -12,5 +12,6 @@ class CfgPatches {
     };
 };
 
+#include "CfgAnimationSourceSounds.hpp"
 #include "CfgEventHandlers.hpp"
 #include "CfgVehicles.hpp"

--- a/addons/shootingrange/functions/fnc_animateTarget.sqf
+++ b/addons/shootingrange/functions/fnc_animateTarget.sqf
@@ -20,15 +20,16 @@ params ["_target", "_state"];
 
 
 private _fnc_animate = {
-    params ["_target", "_state", "_anims"];
+    params ["_target", "_state", "_anims", "_sounds"];
     // Wait animation time before changing animation again
     [{
-        params ["_target", "_state", "_anims"];
-        TRACE_3("Wait Animate",_target,_state,_anims);
+        params ["_target", "_state", "_anims", "_sounds"];
+        TRACE_4("Wait Animate",_target,_state,_anims,_sounds);
         {
             _target animate [_x, _state];
+            [_target, _sounds select _state, 50] call CBA_fnc_globalSay3d;
         } forEach _anims;
-    }, [_target, _state, _anims], 0.3] call ACE_Common_fnc_waitAndExecute;
+    }, [_target, _state, _anims, _sounds], 0.3] call ACE_Common_fnc_waitAndExecute;
 };
 
 
@@ -42,8 +43,8 @@ if (_index != -1) then {
     {
         _anims pushBack _x;
     } forEach (OVAL_TARGET_ANIMS select _index);
-    [_target, _state, _anims] call _fnc_animate;
+    [_target, _state, _anims, ["FD_Target_PopUp_Small_F", "FD_Target_PopDown_Small_F"]] call _fnc_animate;
 } else {
     // Normal target
-    [_target, _state, ["Terc"]] call _fnc_animate;
+    [_target, _state, ["Terc"], ["FD_Target_PopUp_Large_F", "FD_Target_PopDown_Large_F"]] call _fnc_animate;
 };

--- a/addons/shootingrange/functions/fnc_animateTarget.sqf
+++ b/addons/shootingrange/functions/fnc_animateTarget.sqf
@@ -20,16 +20,15 @@ params ["_target", "_state"];
 
 
 private _fnc_animate = {
-    params ["_target", "_state", "_anims", "_sounds"];
+    params ["_target", "_state", "_anims"];
     // Wait animation time before changing animation again
     [{
-        params ["_target", "_state", "_anims", "_sounds"];
-        TRACE_4("Wait Animate",_target,_state,_anims,_sounds);
+        params ["_target", "_state", "_anims"];
+        TRACE_3("Wait Animate",_target,_state,_anims);
         {
             _target animate [_x, _state];
-            [_target, _sounds select _state, 50] call CBA_fnc_globalSay3d;
         } forEach _anims;
-    }, [_target, _state, _anims, _sounds], 0.3] call ACE_Common_fnc_waitAndExecute;
+    }, [_target, _state, _anims], 0.3] call ACE_Common_fnc_waitAndExecute;
 };
 
 
@@ -43,8 +42,8 @@ if (_index != -1) then {
     {
         _anims pushBack _x;
     } forEach (OVAL_TARGET_ANIMS select _index);
-    [_target, _state, _anims, ["FD_Target_PopUp_Small_F", "FD_Target_PopDown_Small_F"]] call _fnc_animate;
+    [_target, _state, _anims] call _fnc_animate;
 } else {
     // Normal target
-    [_target, _state, ["Terc"], ["FD_Target_PopUp_Large_F", "FD_Target_PopDown_Large_F"]] call _fnc_animate;
+    [_target, _state, ["Terc"]] call _fnc_animate;
 };

--- a/addons/shootingrange/functions/fnc_handleHitPart.sqf
+++ b/addons/shootingrange/functions/fnc_handleHitPart.sqf
@@ -52,6 +52,8 @@ if (_shooter != _starter) exitWith {
 };
 
 
+[_controller, "Beep_Target", 50] call CBA_fnc_globalSay3d;
+
 // Mark target as already hit
 _target setVariable [QGVAR(alreadyHit), true];
 

--- a/addons/shootingrange/functions/fnc_handleHitPart.sqf
+++ b/addons/shootingrange/functions/fnc_handleHitPart.sqf
@@ -52,7 +52,7 @@ if (_shooter != _starter) exitWith {
 };
 
 
-[_controller, "Beep_Target", 50] call CBA_fnc_globalSay3d;
+[_controller, "Beep_Target", 25] call CBA_fnc_globalSay3d;
 
 // Mark target as already hit
 _target setVariable [QGVAR(alreadyHit), true];

--- a/addons/shootingrange/functions/fnc_start.sqf
+++ b/addons/shootingrange/functions/fnc_start.sqf
@@ -123,6 +123,7 @@ if (_mode > 1) then {
 
         // Countdown timer notification
         [_textCountdown] call ACE_Common_fnc_displayTextStructured;
+        [_controller, "FD_Timer_F", 50] call CBA_fnc_globalSay3d;
 
     }, [_controller, _textCountdown], _execTime] call ACE_Common_fnc_waitAndExecute;
 
@@ -137,6 +138,7 @@ if (_mode > 1) then {
 
     // Final countdown notification
     [localize LSTRING(Go)] call ACE_Common_fnc_displayTextStructured;
+    [_controller, "FD_Start_F", 50] call CBA_fnc_globalSay3d;
 
     // Notify supervisor(s) (closer than start/stop notifications)
     private _playerName = [ACE_player, true] call ACE_Common_fnc_getName;

--- a/addons/shootingrange/functions/fnc_start.sqf
+++ b/addons/shootingrange/functions/fnc_start.sqf
@@ -123,7 +123,7 @@ if (_mode > 1) then {
 
         // Countdown timer notification
         [_textCountdown] call ACE_Common_fnc_displayTextStructured;
-        [_controller, "FD_Timer_F", 50] call CBA_fnc_globalSay3d;
+        [_controller, "FD_Timer_F", 25] call CBA_fnc_globalSay3d;
 
     }, [_controller, _textCountdown], _execTime] call ACE_Common_fnc_waitAndExecute;
 
@@ -138,7 +138,7 @@ if (_mode > 1) then {
 
     // Final countdown notification
     [localize LSTRING(Go)] call ACE_Common_fnc_displayTextStructured;
-    [_controller, "FD_Start_F", 50] call CBA_fnc_globalSay3d;
+    [_controller, "FD_Start_F", 25] call CBA_fnc_globalSay3d;
 
     // Notify supervisor(s) (closer than start/stop notifications)
     private _playerName = [ACE_player, true] call ACE_Common_fnc_getName;

--- a/addons/shootingrange/functions/fnc_stop.sqf
+++ b/addons/shootingrange/functions/fnc_stop.sqf
@@ -39,6 +39,7 @@ params ["_controller", "_controllers", "_name", "_targets", ["_success", false],
 
 // Notification
 private _playerName = [ACE_player, true] call ACE_Common_fnc_getName;
+[_controller, "FD_Finish_F", 50] call CBA_fnc_globalSay3d;
 
 if (_success) then {
     // Check for zero divisor

--- a/addons/shootingrange/functions/fnc_stop.sqf
+++ b/addons/shootingrange/functions/fnc_stop.sqf
@@ -39,7 +39,7 @@ params ["_controller", "_controllers", "_name", "_targets", ["_success", false],
 
 // Notification
 private _playerName = [ACE_player, true] call ACE_Common_fnc_getName;
-[_controller, "FD_Finish_F", 50] call CBA_fnc_globalSay3d;
+[_controller, "FD_Finish_F", 25] call CBA_fnc_globalSay3d;
 
 if (_success) then {
     // Check for zero divisor


### PR DESCRIPTION
**When merged this pull request will:**
- Adds sound effects to shooting range on:
  - Target hit
  - Target pops up/down
  - Course start
  - Course countdown
  - Course finish
- Closes #135 

- [x] Look into playing sound on animation change rather than only when animation is forced with scripting (pop up/down sounds)