### PR TITLE
Convert CfgPatches authors for 1.60

### DIFF
--- a/addons/air_security/config.cpp
+++ b/addons/air_security/config.cpp
@@ -6,6 +6,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_main"};
+        author = ECSTRING(main,Author);
         authors[] = {"DaC", "Jonpas"};
         authorUrl = "http://www.theseus-aegis.com/";
         VERSION_CONFIG;

--- a/addons/air_security/config.cpp
+++ b/addons/air_security/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_main"};
-        author[]= {"DaC", "Jonpas"};
+        authors[] = {"DaC", "Jonpas"};
         authorUrl = "http://www.theseus-aegis.com/";
         VERSION_CONFIG;
     };

--- a/addons/air_security/config.cpp
+++ b/addons/air_security/config.cpp
@@ -7,6 +7,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_main"};
         author = ECSTRING(main,Author);
+        url = "http://www.theseus-aegis.com/";
         authors[] = {"DaC", "Jonpas"};
         authorUrl = "http://www.theseus-aegis.com/";
         VERSION_CONFIG;

--- a/addons/armory/config.cpp
+++ b/addons/armory/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_main"};
-        author[]= {"Jonpas"};
+        authors[] = {"Jonpas"};
         authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;
     };

--- a/addons/armory/config.cpp
+++ b/addons/armory/config.cpp
@@ -7,6 +7,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_main"};
         author = ECSTRING(main,Author);
+        url = "http://www.theseus-aegis.com/";
         authors[] = {"Jonpas"};
         authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;

--- a/addons/armory/config.cpp
+++ b/addons/armory/config.cpp
@@ -6,6 +6,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_main"};
+        author = ECSTRING(main,Author);
         authors[] = {"Jonpas"};
         authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;

--- a/addons/bodybag/config.cpp
+++ b/addons/bodybag/config.cpp
@@ -6,6 +6,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_main", "ace_medical"};
+        author = ECSTRING(main,Author);
         authors[] = {"Jonpas"};
         authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;

--- a/addons/bodybag/config.cpp
+++ b/addons/bodybag/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_main", "ace_medical"};
-        author[]= {"Jonpas"};
+        authors[] = {"Jonpas"};
         authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;
     };

--- a/addons/bodybag/config.cpp
+++ b/addons/bodybag/config.cpp
@@ -7,6 +7,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_main", "ace_medical"};
         author = ECSTRING(main,Author);
+        url = "http://www.theseus-aegis.com/";
         authors[] = {"Jonpas"};
         authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;

--- a/addons/difficulties/config.cpp
+++ b/addons/difficulties/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_main"};
-        author[]= {"Jonpas"};
+        authors[] = {"Jonpas"};
         authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;
     };

--- a/addons/difficulties/config.cpp
+++ b/addons/difficulties/config.cpp
@@ -7,6 +7,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_main"};
         author = ECSTRING(main,Author);
+        url = "http://www.theseus-aegis.com/";
         authors[] = {"Jonpas"};
         authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;

--- a/addons/difficulties/config.cpp
+++ b/addons/difficulties/config.cpp
@@ -6,6 +6,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_main"};
+        author = ECSTRING(main,Author);
         authors[] = {"Jonpas"};
         authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;

--- a/addons/headless/config.cpp
+++ b/addons/headless/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_main"};
-        author[]= {"Jonpas"};
+        authors[] = {"Jonpas"};
         authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;
     };

--- a/addons/headless/config.cpp
+++ b/addons/headless/config.cpp
@@ -7,6 +7,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_main"};
         author = ECSTRING(main,Author);
+        url = "http://www.theseus-aegis.com/";
         authors[] = {"Jonpas"};
         authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;

--- a/addons/headless/config.cpp
+++ b/addons/headless/config.cpp
@@ -6,6 +6,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_main"};
+        author = ECSTRING(main,Author);
         authors[] = {"Jonpas"};
         authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;

--- a/addons/heavylifter/config.cpp
+++ b/addons/heavylifter/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_main"};
-        author[]= {"Jonpas", "DaC"};
+        authors[] = {"Jonpas", "DaC"};
         authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;
     };

--- a/addons/heavylifter/config.cpp
+++ b/addons/heavylifter/config.cpp
@@ -6,6 +6,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_main"};
+        author = ECSTRING(main,Author);
         authors[] = {"Jonpas", "DaC"};
         authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;

--- a/addons/heavylifter/config.cpp
+++ b/addons/heavylifter/config.cpp
@@ -7,6 +7,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_main"};
         author = ECSTRING(main,Author);
+        url = "http://www.theseus-aegis.com/";
         authors[] = {"Jonpas", "DaC"};
         authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;

--- a/addons/insignia/config.cpp
+++ b/addons/insignia/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_main"};
-        author[]= {"Jonpas"};
+        authors[] = {"Jonpas"};
         authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;
     };

--- a/addons/insignia/config.cpp
+++ b/addons/insignia/config.cpp
@@ -7,6 +7,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_main"};
         author = ECSTRING(main,Author);
+        url = "http://www.theseus-aegis.com/";
         authors[] = {"Jonpas"};
         authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;

--- a/addons/insignia/config.cpp
+++ b/addons/insignia/config.cpp
@@ -6,6 +6,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_main"};
+        author = ECSTRING(main,Author);
         authors[] = {"Jonpas"};
         authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;

--- a/addons/main/config.cpp
+++ b/addons/main/config.cpp
@@ -6,6 +6,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common", "ace_interaction"};
+        author = CSTRING(Author);
         authors[] = {"Jonpas"};
         authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;

--- a/addons/main/config.cpp
+++ b/addons/main/config.cpp
@@ -7,6 +7,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common", "ace_interaction"};
         author = CSTRING(Author);
+        url = "http://www.theseus-aegis.com/";
         authors[] = {"Jonpas"};
         authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;

--- a/addons/main/config.cpp
+++ b/addons/main/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"ace_common", "ace_interaction"};
-        author[]= {"Jonpas"};
+        authors[] = {"Jonpas"};
         authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;
     };

--- a/addons/misc/config.cpp
+++ b/addons/misc/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_main"};
-        author[]= {"Jonpas", "DaC"};
+        authors[] = {"Jonpas", "DaC"};
         authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;
     };

--- a/addons/misc/config.cpp
+++ b/addons/misc/config.cpp
@@ -6,6 +6,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_main"};
+        author = ECSTRING(main,Author);
         authors[] = {"Jonpas", "DaC"};
         authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;

--- a/addons/misc/config.cpp
+++ b/addons/misc/config.cpp
@@ -7,6 +7,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_main"};
         author = ECSTRING(main,Author);
+        url = "http://www.theseus-aegis.com/";
         authors[] = {"Jonpas", "DaC"};
         authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;

--- a/addons/radios/config.cpp
+++ b/addons/radios/config.cpp
@@ -6,6 +6,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_main"};
+        author = ECSTRING(main,Author);
         authors[] = {"DaC", "Jonpas"};
         authorUrl = "http://www.theseus-aegis.com/";
         VERSION_CONFIG;

--- a/addons/radios/config.cpp
+++ b/addons/radios/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_main"};
-        author[]= {"DaC", "Jonpas"};
+        authors[] = {"DaC", "Jonpas"};
         authorUrl = "http://www.theseus-aegis.com/";
         VERSION_CONFIG;
     };

--- a/addons/radios/config.cpp
+++ b/addons/radios/config.cpp
@@ -7,6 +7,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_main"};
         author = ECSTRING(main,Author);
+        url = "http://www.theseus-aegis.com/";
         authors[] = {"DaC", "Jonpas"};
         authorUrl = "http://www.theseus-aegis.com/";
         VERSION_CONFIG;

--- a/addons/ratelmarker/config.cpp
+++ b/addons/ratelmarker/config.cpp
@@ -6,6 +6,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_main"};
+        author = ECSTRING(main,Author);
         authors[] = {"DaC", "Jonpas"};
         authorUrl = "http://www.theseus-aegis.com/";
         VERSION_CONFIG;

--- a/addons/ratelmarker/config.cpp
+++ b/addons/ratelmarker/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_main"};
-        author[]= {"DaC", "Jonpas"};
+        authors[] = {"DaC", "Jonpas"};
         authorUrl = "http://www.theseus-aegis.com/";
         VERSION_CONFIG;
     };

--- a/addons/ratelmarker/config.cpp
+++ b/addons/ratelmarker/config.cpp
@@ -7,6 +7,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_main"};
         author = ECSTRING(main,Author);
+        url = "http://www.theseus-aegis.com/";
         authors[] = {"DaC", "Jonpas"};
         authorUrl = "http://www.theseus-aegis.com/";
         VERSION_CONFIG;

--- a/addons/resources/config.cpp
+++ b/addons/resources/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_main"};
-        author[]= {"DaC", "Jonpas", "Rory"};
+        authors[] = {"DaC", "Jonpas", "Rory"};
         authorUrl = "http://www.theseus-aegis.com";
         VERSION_CONFIG;
     };

--- a/addons/resources/config.cpp
+++ b/addons/resources/config.cpp
@@ -6,6 +6,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_main"};
+        author = ECSTRING(main,Author);
         authors[] = {"DaC", "Jonpas", "Rory"};
         authorUrl = "http://www.theseus-aegis.com";
         VERSION_CONFIG;

--- a/addons/resources/config.cpp
+++ b/addons/resources/config.cpp
@@ -7,6 +7,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_main"};
         author = ECSTRING(main,Author);
+        url = "http://www.theseus-aegis.com/";
         authors[] = {"DaC", "Jonpas", "Rory"};
         authorUrl = "http://www.theseus-aegis.com";
         VERSION_CONFIG;

--- a/addons/shootingrange/config.cpp
+++ b/addons/shootingrange/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_main"};
-        author[]= {"Jonpas"};
+        authors[] = {"Jonpas"};
         authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;
     };

--- a/addons/shootingrange/config.cpp
+++ b/addons/shootingrange/config.cpp
@@ -7,6 +7,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_main"};
         author = ECSTRING(main,Author);
+        url = "http://www.theseus-aegis.com/";
         authors[] = {"Jonpas"};
         authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;

--- a/addons/shootingrange/config.cpp
+++ b/addons/shootingrange/config.cpp
@@ -6,6 +6,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_main"};
+        author = ECSTRING(main,Author);
         authors[] = {"Jonpas"};
         authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;

--- a/addons/zeus/config.cpp
+++ b/addons/zeus/config.cpp
@@ -8,7 +8,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_main", "ace_zeus"};
-        author[]= {"Jonpas"};
+        authors[] = {"Jonpas"};
         authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;
     };

--- a/addons/zeus/config.cpp
+++ b/addons/zeus/config.cpp
@@ -9,6 +9,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_main", "ace_zeus"};
         author = ECSTRING(main,Author);
+        url = "http://www.theseus-aegis.com/";
         authors[] = {"Jonpas"};
         authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;

--- a/addons/zeus/config.cpp
+++ b/addons/zeus/config.cpp
@@ -8,6 +8,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_main", "ace_zeus"};
+        author = ECSTRING(main,Author);
         authors[] = {"Jonpas"};
         authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;

--- a/extras/blank/config.cpp
+++ b/extras/blank/config.cpp
@@ -6,7 +6,9 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_main"};
-        author[]= {""};
+        author = ECSTRING(main,Author);
+        url = "http://www.theseus-aegis.com/";
+        authors[] = {""};
         authorUrl = "";
         VERSION_CONFIG;
     };

--- a/optionals/compat_cha_av8b/config.cpp
+++ b/optionals/compat_cha_av8b/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"cha_av8b", "tac_heavylifter"};
-        author[]= {"Jonpas"};
+        authors[] = {"Jonpas"};
         authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;
     };

--- a/optionals/compat_cha_av8b/config.cpp
+++ b/optionals/compat_cha_av8b/config.cpp
@@ -7,6 +7,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"cha_av8b", "tac_heavylifter"};
         author = ECSTRING(main,Author);
+        url = "http://www.theseus-aegis.com/";
         authors[] = {"Jonpas"};
         authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;

--- a/optionals/compat_cha_av8b/config.cpp
+++ b/optionals/compat_cha_av8b/config.cpp
@@ -6,6 +6,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"cha_av8b", "tac_heavylifter"};
+        author = ECSTRING(main,Author);
         authors[] = {"Jonpas"};
         authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;

--- a/optionals/compat_rhsafrf/config.cpp
+++ b/optionals/compat_rhsafrf/config.cpp
@@ -6,6 +6,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_heavylifter"};
+        author = ECSTRING(main,Author);
         authors[] = {"Jonpas"};
         authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;

--- a/optionals/compat_rhsafrf/config.cpp
+++ b/optionals/compat_rhsafrf/config.cpp
@@ -7,6 +7,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_heavylifter"};
         author = ECSTRING(main,Author);
+        url = "http://www.theseus-aegis.com/";
         authors[] = {"Jonpas"};
         authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;

--- a/optionals/compat_rhsafrf/config.cpp
+++ b/optionals/compat_rhsafrf/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_heavylifter"};
-        author[]= {"Jonpas"};
+        authors[] = {"Jonpas"};
         authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;
     };

--- a/optionals/compat_rhsusf/config.cpp
+++ b/optionals/compat_rhsusf/config.cpp
@@ -6,6 +6,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_heavylifter"};
+        author = ECSTRING(main,Author);
         authors[] = {"Jonpas"};
         authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;

--- a/optionals/compat_rhsusf/config.cpp
+++ b/optionals/compat_rhsusf/config.cpp
@@ -7,6 +7,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_heavylifter"};
         author = ECSTRING(main,Author);
+        url = "http://www.theseus-aegis.com/";
         authors[] = {"Jonpas"};
         authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;

--- a/optionals/compat_rhsusf/config.cpp
+++ b/optionals/compat_rhsusf/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_heavylifter"};
-        author[]= {"Jonpas"};
+        authors[] = {"Jonpas"};
         authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;
     };

--- a/optionals/tban_armed/config.cpp
+++ b/optionals/tban_armed/config.cpp
@@ -6,6 +6,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_main", "Taliban_fighters", "hlcweapons_aks"};
+        author = ECSTRING(main,Author);
         authors[] = {"Jonpas", "Rory"};
         authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;

--- a/optionals/tban_armed/config.cpp
+++ b/optionals/tban_armed/config.cpp
@@ -7,6 +7,7 @@ class CfgPatches {
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_main", "Taliban_fighters", "hlcweapons_aks"};
         author = ECSTRING(main,Author);
+        url = "http://www.theseus-aegis.com/";
         authors[] = {"Jonpas", "Rory"};
         authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;

--- a/optionals/tban_armed/config.cpp
+++ b/optionals/tban_armed/config.cpp
@@ -6,7 +6,7 @@ class CfgPatches {
         weapons[] = {};
         requiredVersion = REQUIRED_VERSION;
         requiredAddons[] = {"tac_main", "Taliban_fighters", "hlcweapons_aks"};
-        author[]= {"Jonpas", "Rory"};
+        authors[] = {"Jonpas", "Rory"};
         authorUrl = "https://github.com/jonpas";
         VERSION_CONFIG;
     };


### PR DESCRIPTION
**When merged this pull request will:**
- Close #173 
- Fix `author/ is not a value`
- Convert `author[]` to `authors[]`
- Add `author` entry with value `ECSTRING(main,Author)`/`CSTRING(Author)`
- Add `url` entry with value `"http://www.theseus-aegis.com/"`
- Fix missing space in front of `=` in `author[]`
- Update `blank` component as well

#### Regex used
**Converting `author[]` to `authors[]`:**
Find:
```
author\[\]= {([\s\S]*?)};
```
Replace:
```
authors\[\] = {$1};
```

**Adding `author` and `url`:**
Find:
```
class CfgPatches([\s\S]*?);([\s]*?)authors\[\]
```
Replace:
```
class CfgPatches$1;\n        author = ECSTRING\(main,Author\);$2authors\[\]
class CfgPatches$1;\n        url = "http://ace3mod.com";$2authors\[\]
```