### PR TITLE
Add Armory compatible items sub-category and fix tooltips

### DIFF
--- a/addons/armory/XEH_PREP.hpp
+++ b/addons/armory/XEH_PREP.hpp
@@ -15,6 +15,7 @@ PREP(getBoxContents);
 PREP(getDataVanilla);
 PREP(getDataChronos);
 PREP(init);
+PREP(isCompatible);
 PREP(moduleInit);
 PREP(openArmory);
 PREP(sendData);

--- a/addons/armory/functions/fnc_dialogControl_list.sqf
+++ b/addons/armory/functions/fnc_dialogControl_list.sqf
@@ -50,7 +50,8 @@ private _subCategories = [_armoryData, _hasCompatibleItems] call FUNC(extractSub
 // Fill Dropdown
 lbClear DROPDOWN; // Clear Dropdown
 {
-    lbAdd [DROPDOWN, _x];
+    lbAdd [DROPDOWN, _x select 0];
+    lbSetTooltip [DROPDOWN, _forEachIndex, _x select 1];
 } forEach _subCategories;
 
 // Set initial value to 'All' (will not fire onLBSelChanged)

--- a/addons/armory/functions/fnc_dialogControl_list.sqf
+++ b/addons/armory/functions/fnc_dialogControl_list.sqf
@@ -44,7 +44,8 @@ if (_selectedCategory == "stash") then {
 if (_exit) exitWith {};
 
 // Extract sub-categories
-private _subCategories = [_armoryData] call FUNC(extractSubCategories);
+private _hasCompatibleItems = _selectedCategory in ["ammo", "attachment"];
+private _subCategories = [_armoryData, _hasCompatibleItems] call FUNC(extractSubCategories);
 
 // Fill Dropdown
 lbClear DROPDOWN; // Clear Dropdown

--- a/addons/armory/functions/fnc_dialogControl_populateList.sqf
+++ b/addons/armory/functions/fnc_dialogControl_populateList.sqf
@@ -56,7 +56,7 @@ _armoryData sort true; // Errors when used in combination with forEach
 
             private _quantityList = [_quantity, "∞"] select (_configCfg == "CfgUnitInsignia");
             lnbAddRow [NLIST, ["", _displayName, _quantityList]];
-            lbSetTooltip [NLIST, _rowNum, _tooltip];
+            lbSetTooltip [NLIST, _rowNum * 3, _tooltip]; // Requires multiplication by 3 to be set on proper index (no idea why)
 
             // Set hidden data with classname to displayName column and quantity to quantity column
             lnbSetData [NLIST, [_rowNum, 1], _className];

--- a/addons/armory/functions/fnc_dialogControl_populateList.sqf
+++ b/addons/armory/functions/fnc_dialogControl_populateList.sqf
@@ -17,9 +17,9 @@
 
 params ["_armoryData"];
 
-private _selectedSubCategory = lbText [DROPDOWN, (lbSelection CTRL(DROPDOWN)) select 0]; // SubCategory
+private _selSubCategory = lbText [DROPDOWN, (lbSelection CTRL(DROPDOWN)) select 0]; // SubCategory
 
-TRACE_2("Populating list",_armoryData,_selectedSubCategory);
+TRACE_2("Populating list",_armoryData,_selSubCategory);
 
 // Clear List
 lnbClear NLIST;
@@ -43,7 +43,7 @@ _armoryData sort true; // Errors when used in combination with forEach
         if (_configCfg == "") exitWith {ACE_LOGERROR_2("Config type not found for classname: %1, Config return: %2",_className,_configCfg)};
 
         // Check sub-category for proper listing
-        if (_selectedSubCategory == "" || {_selectedSubCategory == _subCategory}) then {
+        if (_selSubCategory == "" || {_selSubCategory == _subCategory} || {_selSubCategory == "Compatible" && [_className] call FUNC(isCompatible)}) then {
             private _displayName = getText (configFile >> _configCfg >> _className >> "displayName"); // Get display name from config
             private _tooltip = _displayName; // Display name gets cropped
 

--- a/addons/armory/functions/fnc_extractSubCategories.sqf
+++ b/addons/armory/functions/fnc_extractSubCategories.sqf
@@ -4,28 +4,30 @@
  *
  * Arguments:
  * 0: Requested Menu <STRING>
+ * 1: Compatible Category <BOOL>
  *
  * Return Value:
  * Sub-Categories <ARRAY>
  *
  * Example:
- * ["menu"] call tac_armory_fnc_extractSubCategories
+ * ["menu", true] call tac_armory_fnc_extractSubCategories
  *
  * Public: No
  */
 #include "script_component.hpp"
 
-params ["_armoryData"];
+params ["_armoryData", "_compatible"];
 
-private _subCategories = ["All"];
+private _dataSubCategories = [];
 {
     _x params ["", "_subCategory"];
 
-    if !(_subCategory in _subCategories) then {
-        _subCategories pushBack _subCategory;
-    };
+    _dataSubCategories pushBackUnique _subCategory;
 } forEach _armoryData;
 
-_subCategories sort true;
+_dataSubCategories sort true;
+
+private _subCategories = [["All"], ["All", "Compatible"]] select _compatible;
+_subCategories append _dataSubCategories;
 
 _subCategories

--- a/addons/armory/functions/fnc_extractSubCategories.sqf
+++ b/addons/armory/functions/fnc_extractSubCategories.sqf
@@ -18,16 +18,21 @@
 
 params ["_armoryData", "_compatible"];
 
+private _subCategories = [ ["All", ""] ];
+if (_compatible) then {
+    _subCategories pushBack ["Compatible", localize LSTRING(ShowOnlyCompatible)];
+};
+
 private _dataSubCategories = [];
 {
     _x params ["", "_subCategory"];
 
-    _dataSubCategories pushBackUnique _subCategory;
+    _dataSubCategories pushBackUnique [_subCategory, ""];
 } forEach _armoryData;
 
 _dataSubCategories sort true;
 
-private _subCategories = [["All"], ["All", "Compatible"]] select _compatible;
 _subCategories append _dataSubCategories;
 
+TRACE_1("SubCategories",_subCategories);
 _subCategories

--- a/addons/armory/functions/fnc_getDataVanilla.sqf
+++ b/addons/armory/functions/fnc_getDataVanilla.sqf
@@ -25,98 +25,96 @@ if (isNull _object) exitWith {
 };
 
 private _armoryDataVar = _object getVariable [QGVAR(armoryData), []];
-
-// Verify armory data
 private _armoryData = [];
-{
-    _x params [
-        ["_category", "", [""]],
-        ["_className", "", [""]],
-        ["_subCategory", "", [""]],
-        ["_description", "", [""]],
-        ["_quantity", 1, [0]]
-    ];
 
-    if (_category == _selectedCategory && {_className != ""} && {_subCategory != ""} && {_quantity > 0}) then {
-        _armoryData pushBack [_className, _subCategory, _description, str _quantity];
+#ifndef DEBUG_MODE_FULL
+    // Verify armory data
+    {
+        _x params [
+            ["_category", "", [""]],
+            ["_className", "", [""]],
+            ["_subCategory", "", [""]],
+            ["_description", "", [""]],
+            ["_quantity", 1, [0]]
+        ];
+
+        if (_category == _selectedCategory && {_className != ""} && {_subCategory != ""} && {_quantity > 0}) then {
+            _armoryData pushBack [_className, _subCategory, _description, str _quantity];
+        };
+    } forEach _armoryDataVar;
+#else
+    // Rifles
+    if (_selectedCategory == "rifle") then {
+        _armoryData = [
+            // Classname, Subcategory, Description, Quantity
+            ["arifle_MX_F", "Assault Rifle", "Blabla, this item, blabla", "23"],
+            ["srifle_DMR_01_F", "Marksman Rifle", "Blabla, this item, blabla", "4"],
+            ["srifle_EBR_F", "Marksman Rifle", "Blabla, this item, blabla", "5"],
+            ["arifle_Katiba_GL_F", "Assault Rifle", "Blabla, this item, blabla", "45"],
+            ["arifle_Mk20C_plain_F", "Assault Rifle", "Blabla, this item, blabla", "18"],
+            ["arifle_Mk20C_plain_F", "Assault Rifle", "Blabla, this item, blabla", "20"],
+            ["arifle_MXC_F", "Shotgun", "Blabla, this item, blabla", "33"],
+            ["arifle_MXC_F", "Shotgun", "Blabla, this item, blabla", "33"],
+            ["arifle_MXC_F", "Shotgun", "Blabla, this item, blabla", "33"],
+            ["arifle_MXC_F", "Shotgun", "Blabla, this item, blabla", "33"],
+            ["arifle_MXC_F", "Shotgun", "Blabla, this item, blabla", "33"],
+            ["arifle_MXC_F", "Shotgun", "Blabla, this item, blabla", "33"],
+            ["arifle_MXC_F", "Shotgun", "Blabla, this item, blabla", "33"],
+            ["arifle_MXC_F", "Shotgun", "Blabla, this item, blabla", "33"],
+            ["arifle_MXC_F", "Shotgun", "Blabla, this item, blabla", "33"],
+            ["arifle_MXC_F", "Shotgun", "Blabla, this item, blabla", "33"],
+            ["arifle_MXC_F", "Shotgun", "Blabla, this item, blabla", "33"],
+            ["arifle_MXC_F", "Shotgun", "Blabla, this item, blabla", "33"],
+            ["arifle_MXC_F", "Shotgun", "Blabla, this item, blabla", "33"],
+            ["arifle_MXC_F", "Shotgun", "Blabla, this item, blabla", "33"],
+            ["arifle_MXC_F", "Shotgun", "Blabla, this item, blabla", "33"]
+        ];
     };
-} forEach _armoryDataVar;
-
-
-// TESTING
-/*private _armoryData = [];
-
-// Rifles
-if (_selectedCategory == "rifle") then {
-    _armoryData = [
-        // Classname, Subcategory, Description, Quantity
-        ["arifle_MX_F", "Assault Rifle", "Blabla, this item, blabla", "23"],
-        ["srifle_DMR_01_F", "Marksman Rifle", "Blabla, this item, blabla", "4"],
-        ["srifle_EBR_F", "Marksman Rifle", "Blabla, this item, blabla", "5"],
-        ["arifle_Katiba_GL_F", "Assault Rifle", "Blabla, this item, blabla", "45"],
-        ["arifle_Mk20C_plain_F", "Assault Rifle", "Blabla, this item, blabla", "18"],
-        ["arifle_Mk20C_plain_F", "Assault Rifle", "Blabla, this item, blabla", "20"],
-        ["arifle_MXC_F", "Shotgun", "Blabla, this item, blabla", "33"],
-        ["arifle_MXC_F", "Shotgun", "Blabla, this item, blabla", "33"],
-        ["arifle_MXC_F", "Shotgun", "Blabla, this item, blabla", "33"],
-        ["arifle_MXC_F", "Shotgun", "Blabla, this item, blabla", "33"],
-        ["arifle_MXC_F", "Shotgun", "Blabla, this item, blabla", "33"],
-        ["arifle_MXC_F", "Shotgun", "Blabla, this item, blabla", "33"],
-        ["arifle_MXC_F", "Shotgun", "Blabla, this item, blabla", "33"],
-        ["arifle_MXC_F", "Shotgun", "Blabla, this item, blabla", "33"],
-        ["arifle_MXC_F", "Shotgun", "Blabla, this item, blabla", "33"],
-        ["arifle_MXC_F", "Shotgun", "Blabla, this item, blabla", "33"],
-        ["arifle_MXC_F", "Shotgun", "Blabla, this item, blabla", "33"],
-        ["arifle_MXC_F", "Shotgun", "Blabla, this item, blabla", "33"],
-        ["arifle_MXC_F", "Shotgun", "Blabla, this item, blabla", "33"],
-        ["arifle_MXC_F", "Shotgun", "Blabla, this item, blabla", "33"],
-        ["arifle_MXC_F", "Shotgun", "Blabla, this item, blabla", "33"]
-    ];
-};
-if (_selectedCategory == "ammo") then {
-    _armoryData = [
-        // Classname, Subcategory, Description, Quantity
-        ["30Rnd_65x39_caseless_mag", "Magazine", "Blabla, this item, blabla", "333"],
-        ["100Rnd_65x39_caseless_mag", "Magazine", "Blabla, this item, blabla", "123"],
-        ["NLAW_F", "Missile", "Blabla, this item, blabla", "7"],
-        ["1Rnd_HE_Grenade_shell", "Shell", "Blabla, this item, blabla", "19"],
-        ["SmokeShellBlue", "Shell", "Blabla, this item, blabla", "15"]
-    ];
-};
-if (_selectedCategory == "item") then {
-    _armoryData = [
-        // Classname, Subcategory, Description, Quantity
-        ["NVGoggles", "Headgear", "Blabla, this item, blabla", "23"],
-        ["Laserdesignator", "Item", "Blabla, this item, blabla", "7"],
-        ["ItemGPS", "Item", "Blabla, this item, blabla", "5"],
-        ["MediKit", "Item", "Blabla, this item, blabla", "2"],
-        ["ToolKit", "Item", "Blabla, this item, blabla", "18"],
-        ["B_UavTerminal", "Item", "Blabla, this item, blabla", "20"]
-    ];
-};
-if (_selectedCategory == "attachment") then {
-    _armoryData = [
-        // Classname, Subcategory, Description, Quantity
-        ["optic_Hamr", "Optic", "Blabla, this item, blabla", "4"],
-        ["optic_Aco", "Optic", "Blabla, this item, blabla", "45"],
-        ["optic_DMS", "Optic", "Blabla, this item, blabla", "33"],
-        ["muzzle_snds_93mmg", "Muzzle", "Blabla, this item, blabla", "6"],
-        ["muzzle_snds_H", "Muzzle", "Blabla, this item, blabla", "13"],
-        ["optic_MRD", "Optic", "Blabla, this item, blabla", "1"]
-    ];
-};
-if (_selectedCategory == "wearable") then {
-    _armoryData = [
-        // Classname, Subcategory, Description, Quantity
-        ["G_Bandanna_Shades", "Goggles", "Blabla, this item, blabla", "4"]
-    ];
-};
-if (_selectedCategory == "insignia") then {
-    private _config = configFile >> "CfgUnitInsignia";
-    for "_x" from 0 to (count _config - 1) do {
-        private _configName = configName (_config select _x);
-        _armoryData pushBack [_configName, "Insignia", "Insignia", "1"];
+    if (_selectedCategory == "ammo") then {
+        _armoryData = [
+            // Classname, Subcategory, Description, Quantity
+            ["30Rnd_65x39_caseless_mag", "Magazine", "Blabla, this item, blabla", "333"],
+            ["100Rnd_65x39_caseless_mag", "Magazine", "Blabla, this item, blabla", "123"],
+            ["NLAW_F", "Missile", "Blabla, this item, blabla", "7"],
+            ["1Rnd_HE_Grenade_shell", "Shell", "Blabla, this item, blabla", "19"],
+            ["SmokeShellBlue", "Shell", "Blabla, this item, blabla", "15"]
+        ];
     };
-};*/
+    if (_selectedCategory == "item") then {
+        _armoryData = [
+            // Classname, Subcategory, Description, Quantity
+            ["NVGoggles", "Headgear", "Blabla, this item, blabla", "23"],
+            ["Laserdesignator", "Item", "Blabla, this item, blabla", "7"],
+            ["ItemGPS", "Item", "Blabla, this item, blabla", "5"],
+            ["MediKit", "Item", "Blabla, this item, blabla", "2"],
+            ["ToolKit", "Item", "Blabla, this item, blabla", "18"],
+            ["B_UavTerminal", "Item", "Blabla, this item, blabla", "20"]
+        ];
+    };
+    if (_selectedCategory == "attachment") then {
+        _armoryData = [
+            // Classname, Subcategory, Description, Quantity
+            ["optic_Hamr", "Optic", "Blabla, this item, blabla", "4"],
+            ["optic_Aco", "Optic", "Blabla, this item, blabla", "45"],
+            ["optic_DMS", "Optic", "Blabla, this item, blabla", "33"],
+            ["muzzle_snds_93mmg", "Muzzle", "Blabla, this item, blabla", "6"],
+            ["muzzle_snds_H", "Muzzle", "Blabla, this item, blabla", "13"],
+            ["optic_MRD", "Optic", "Blabla, this item, blabla", "1"]
+        ];
+    };
+    if (_selectedCategory == "wearable") then {
+        _armoryData = [
+            // Classname, Subcategory, Description, Quantity
+            ["G_Bandanna_Shades", "Goggles", "Blabla, this item, blabla", "4"]
+        ];
+    };
+    if (_selectedCategory == "insignia") then {
+        private _config = configFile >> "CfgUnitInsignia";
+        for "_x" from 0 to (count _config - 1) do {
+            private _configName = configName (_config select _x);
+            _armoryData pushBack [_configName, "Insignia", "Insignia", "1"];
+        };
+    };
+#endif
 
 _armoryData

--- a/addons/armory/functions/fnc_isCompatible.sqf
+++ b/addons/armory/functions/fnc_isCompatible.sqf
@@ -20,11 +20,10 @@ params ["_itemClass"];
 _itemClass = toLower _itemClass;
 
 {
-    private _compatibleItems = [_x] call CBA_fnc_compatibleItems apply (toLower _x);
+    private _compatibleItems = ([_x] call CBA_fnc_compatibleItems) apply {toLower _x};
 
     if (_itemClass in _compatibleItems) exitWith {
         true
     };
+    false
 } forEach (weapons ACE_player);
-
-false

--- a/addons/armory/functions/fnc_isCompatible.sqf
+++ b/addons/armory/functions/fnc_isCompatible.sqf
@@ -1,0 +1,30 @@
+/*
+ * Author: Jonpas
+ * Checks if magazine or attachment is compatible with any weapon carried by player.
+ *
+ * Arguments:
+ * 0: Item Classname <STRING>
+ *
+ * Return Value:
+ * Compatible <BOOL>
+ *
+ * Example:
+ * ["itemClass"] call tac_armory_fnc_isCompatible
+ *
+ * Public: No
+ */
+#include "script_component.hpp"
+
+params ["_itemClass"];
+
+_itemClass = toLower _itemClass;
+
+{
+    private _compatibleItems = [_x] call CBA_fnc_compatibleItems apply (toLower _x);
+
+    if (_itemClass in _compatibleItems) exitWith {
+        true
+    };
+} forEach (weapons ACE_player);
+
+false

--- a/addons/armory/script_component.hpp
+++ b/addons/armory/script_component.hpp
@@ -1,8 +1,8 @@
 #define COMPONENT armory
 #include "\x\tac\addons\main\script_mod.hpp"
 
-// #define DEBUG_MODE_FULL
-// #define DISABLE_COMPILE_CACHE
+#define DEBUG_MODE_FULL
+#define DISABLE_COMPILE_CACHE
 // #define CBA_DEBUG_SYNCHRONOUS
 // #define ENABLE_PERFORMANCE_COUNTERS
 

--- a/addons/armory/script_component.hpp
+++ b/addons/armory/script_component.hpp
@@ -1,8 +1,8 @@
 #define COMPONENT armory
 #include "\x\tac\addons\main\script_mod.hpp"
 
-#define DEBUG_MODE_FULL
-#define DISABLE_COMPILE_CACHE
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
 // #define CBA_DEBUG_SYNCHRONOUS
 // #define ENABLE_PERFORMANCE_COUNTERS
 

--- a/addons/armory/stringtable.xml
+++ b/addons/armory/stringtable.xml
@@ -112,5 +112,8 @@
             <English>Container is full! Make space for retrieval.</English>
             <German>Der Container ist voll! Schaffe Platz zum herausholen.</German>
         </Key>
+        <Key ID="STR_TAC_Armory_ShowOnlyCompatible">
+            <English>Show only items compatible with equipped weapons.</English>
+        </Key>
     </Package>
 </Project>


### PR DESCRIPTION
**When merged this pull request will:**
- Fixes list tooltips
- Work on #84 
- Adds "Compatible" sub-category which shows only ammo/attachments compatible with weapons in player's inventory
- Changes vanilla data debug work with `DEBUG_MODE_FULL` macro