### PR TITLE
Add multiple hit setting to shooting range targets

### DIFF
--- a/addons/shootingrange/CfgVehicles.hpp
+++ b/addons/shootingrange/CfgVehicles.hpp
@@ -23,6 +23,12 @@ class CfgVehicles {
                 typeName = "STRING";
                 defaultValue = "";
             };
+            class Hits {
+                displayName = CSTRING(Hits);
+                description = CSTRING(HitsDesc);
+                typeName = "STRING";
+                defaultValue = "";
+            };
             class TargetsInvalid {
                 displayName = CSTRING(TargetsInvalid);
                 description = CSTRING(TargetsInvalidDesc);

--- a/addons/shootingrange/CfgVehicles.hpp
+++ b/addons/shootingrange/CfgVehicles.hpp
@@ -143,6 +143,9 @@ class CfgVehicles {
                 sound = QGVAR(TargetLargeSound);
             };
         };
+        class EventHandlers {
+            hitPart = QUOTE((_this select 0) call FUNC(handleHitPart)); // Replace vanilla script handler
+        };
     };
 
     class Land_Target_Oval_F: TargetBase {
@@ -150,6 +153,9 @@ class CfgVehicles {
             class Left_Rotate {
                 sound = QGVAR(TargetSmallSound);
             };
+        };
+        class EventHandlers {
+            hitPart = QUOTE((_this select 0) call FUNC(handleHitPart)); // Replace vanilla script handler
         };
     };
 };

--- a/addons/shootingrange/CfgVehicles.hpp
+++ b/addons/shootingrange/CfgVehicles.hpp
@@ -135,6 +135,12 @@ class CfgVehicles {
                 typeName = "BOOL";
                 defaultValue = 1;
             };
+            class ShowHits {
+                displayName = CSTRING(ShowHits);
+                description = CSTRING(ShowHitsDesc);
+                typeName = "BOOL";
+                defaultValue = 1;
+            };
         };
         class ModuleDescription {
             description = CSTRING(ModuleDesc);

--- a/addons/shootingrange/XEH_preInit.sqf
+++ b/addons/shootingrange/XEH_preInit.sqf
@@ -4,6 +4,4 @@ ADDON = false;
 
 #include "XEH_PREP.hpp"
 
-GVAR(animCache) = [];
-
 ADDON = true;

--- a/addons/shootingrange/XEH_preInit.sqf
+++ b/addons/shootingrange/XEH_preInit.sqf
@@ -4,4 +4,6 @@ ADDON = false;
 
 #include "XEH_PREP.hpp"
 
+GVAR(animCache) = [];
+
 ADDON = true;

--- a/addons/shootingrange/functions/fnc_addConfigDurations.sqf
+++ b/addons/shootingrange/functions/fnc_addConfigDurations.sqf
@@ -41,6 +41,6 @@ private _actions = [];
     ];
 } forEach _durations;
 
-TRACE_1("Children actions",_actions);
+//TRACE_1("Children actions",_actions);
 
 _actions

--- a/addons/shootingrange/functions/fnc_addConfigPauseDurations.sqf
+++ b/addons/shootingrange/functions/fnc_addConfigPauseDurations.sqf
@@ -38,6 +38,6 @@ private _actions = [];
     ];
 } forEach _pauseDurations;
 
-TRACE_1("Children actions",_actions);
+//TRACE_1("Children actions",_actions);
 
 _actions

--- a/addons/shootingrange/functions/fnc_addConfigTargetAmounts.sqf
+++ b/addons/shootingrange/functions/fnc_addConfigTargetAmounts.sqf
@@ -38,6 +38,6 @@ private _actions = [];
     ];
 } forEach _targetAmounts;
 
-TRACE_1("Children actions",_actions);
+//TRACE_1("Children actions",_actions);
 
 _actions

--- a/addons/shootingrange/functions/fnc_animateTarget.sqf
+++ b/addons/shootingrange/functions/fnc_animateTarget.sqf
@@ -18,17 +18,12 @@
 
 params ["_target", "_state"];
 
-
 private _fnc_animate = {
     params ["_target", "_state", "_anims"];
-    // Wait animation time before changing animation again
-    [{
-        params ["_target", "_state", "_anims"];
-        //TRACE_3("Wait Animate",_target,_state,_anims);
-        {
-            _target animate [_x, _state];
-        } forEach _anims;
-    }, [_target, _state, _anims], 0.3] call CBA_fnc_waitAndExecute;
+    //TRACE_3("Animate",_target,_state,_anims);
+    {
+        _target animate [_x, _state];
+    } forEach _anims;
 };
 
 

--- a/addons/shootingrange/functions/fnc_canActivateTrigger.sqf
+++ b/addons/shootingrange/functions/fnc_canActivateTrigger.sqf
@@ -21,4 +21,4 @@ params ["_controller", "_target"];
 (_controller getVariable [QGVAR(running), false]) &&
 {(_controller getVariable [QGVAR(starter), objNull]) in thisList} &&
 {!isNil QGVAR(targetGroup) && {_target in GVAR(targetGroup)}} &&
-{!isNil QGVAR(timeStartCountdown) && {diag_tickTime >= GVAR(timeStartCountdown) + (_controller getVariable [QGVAR(countdownTime), COUNTDOWNTIME_DEFAULT])}}
+{GVAR(firstRun)}

--- a/addons/shootingrange/functions/fnc_checkConfig.sqf
+++ b/addons/shootingrange/functions/fnc_checkConfig.sqf
@@ -58,17 +58,18 @@ switch (_mode) do {
 };
 
 private _text = "";
-private _size = 2.5;
+private _size = 4;
 
-if (_mode == 1) exitWith {
+if (_mode == 1) then {
     _text = format ["%1 %2 %3<br/><br/>%4: %5<br/>%6: %7<br/>%8: %9s<br/>%10: %11s", localize LSTRING(Range), _name, localize LSTRING(Configuration), localize LSTRING(Mode), _textMode, _textConfig, _textDurationOrTargetAmount, localize LSTRING(PauseDuration), _pauseDuration, localize LSTRING(CountdownTime), _countdownTime];
+    _size = _size + 0.5;
 };
 
-if (_mode in [2, 3, 5]) exitWith {
+if (_mode in [2, 3, 5]) then {
     _text = format ["%1 %2 %3<br/><br/>%4: %5<br/>%6: %7<br/>%8: %9s", localize LSTRING(Range), _name, localize LSTRING(Configuration), localize LSTRING(Mode), _textMode, _textConfig, _textDurationOrTargetAmount, localize LSTRING(CountdownTime), _countdownTime];
 };
 
-if (_mode == 4) exitWith {
+if (_mode == 4) then {
     _text = format ["%1 %2 %3<br/><br/>%4: %5<br/>%6: %7s", localize LSTRING(Range), _name, localize LSTRING(Configuration), localize LSTRING(Mode), _textMode, localize LSTRING(CountdownTime), _countdownTime];
 };
 

--- a/addons/shootingrange/functions/fnc_create.sqf
+++ b/addons/shootingrange/functions/fnc_create.sqf
@@ -5,25 +5,26 @@
  * Arguments:
  * 0: Name <STRING> (default: "")
  * 1: Targets <ARRAY>
- * 2: Hits <ARRAY>
- * 3: Controllers <ARRAY>
- * 4: Mode (1 = Time, 2 = Hit (Time Limited), 3 = Hit (Target Limited), 4 = Trigger, 5 = Rampage) <NUMBER> (default: 1)
- * 5: Durations <ARRAY> (default: [0, 30, 60, 150, 300])
- * 6: Default Duration <NUMBER> (default: 60)
- * 7: Pause Durations <ARRAY> (default: [1, 2, 3, 4, 5])
- * 8: Default Pause Duration <NUMBER> (default: 5)
- * 9: Countdown Times <ARRAY> (default: 6, 9, 12, 15)
- * 10: Default Countdown Time <NUMBER> (default: 9)
- * 11: Trigger Markers <ARRAY> (default: [])
- * 12: Pop on Trigger Exit <BOOL> (default: true)
- * 13: Invalid Targets <ARRAY> (default: [])
- * 14: Sound Sources <ARRAY> (default: [])
+ * 2: Controllers <ARRAY>
+ * 3: Mode (1 = Time, 2 = Hit (Time Limited), 3 = Hit (Target Limited), 4 = Trigger, 5 = Rampage) <NUMBER> (default: 1)
+ * 4: Durations <ARRAY> (default: [0, 30, 60, 150, 300])
+ * 5: Default Duration <NUMBER> (default: 60)
+ * 6: Pause Durations <ARRAY> (default: [1, 2, 3, 4, 5])
+ * 7: Default Pause Duration <NUMBER> (default: 5)
+ * 8: Countdown Times <ARRAY> (default: 6, 9, 12, 15)
+ * 9: Default Countdown Time <NUMBER> (default: 9)
+ * 10: Trigger Markers <ARRAY> (default: [])
+ * 11: Pop on Trigger Exit <BOOL> (default: true)
+ * 12: Invalid Targets <ARRAY> (default: [])
+ * 13: Sound Sources <ARRAY> (default: [])
+ * 14: Hits <ARRAY> (default: [])
+ * 15: Show Hits <BOOL>
  *
  * Return Value:
  * None
  *
  * Example:
- * ["range", [target1, target2], [2, 2] [controller1, controller2], 1, [30, 60], 60,  [3, 5], 5, 10, [marker1, marker2]] call tac_shootingrange_fnc_create;
+ * ["range", [target1, target2], [controller1, controller2], 1, [30, 60], 60,  [3, 5], 5, 10, [marker1, marker2], [2, 2], true] call tac_shootingrange_fnc_create;
  *
  * Public: Yes
  */
@@ -32,7 +33,6 @@
 params [
     ["_name", [""], [""] ],
     ["_targets", [], [[]] ],
-    ["_hits", [], [[]] ],
     ["_controllers", [], [[]] ],
     ["_mode", MODE_DEFAULT, [0] ],
     ["_durations", DURATIONS_DEFAULT, [[]] ],
@@ -46,7 +46,9 @@ params [
     ["_triggerMarkers", [], [[]] ],
     ["_popOnTriggerExit", POPONTRIGGEREXIT_DEFAULT, [true] ],
     ["_targetsInvalid", [], [[]] ],
-    ["_soundSources", [], [[]] ]
+    ["_soundSources", [], [[]] ],
+    ["_hits", HITS_DEFAULT, [[]] ],
+    ["_showHits", SHOWHITS_DEFAULT, [true] ]
 ];
 
 // Verify data
@@ -87,12 +89,9 @@ if (_durations isEqualTo []) then {
     _durations pushBack 0; // Add infinite duration
 };
 
-if (_hits isEqualTo []) then {
-    _hits = [1];
-};
-if (count _hits == 1) then {
+if (count _hits < 2) then {
     {
-        _hits pushBack (_hits select 0);
+        _hits pushBack ([_hits select 0, 1] select (_hits isEqualTo []));
     } forEach _targets;
 };
 
@@ -148,6 +147,7 @@ _countdownTimes sort true;
         _x setVariable [QGVAR(mode), _mode, true];
     };
     _x setVariable [QGVAR(soundSources), _controllers + _soundSources];
+    _x setVariable [QGVAR(showHits), _showHits];
 
     // Main
     private _actionRange = [
@@ -351,7 +351,6 @@ if (_mode == 4) then {
         _triggers pushBack _trigger;
     } forEach _triggerMarkers;
 };
-
 
 // Set up targets
 {

--- a/addons/shootingrange/functions/fnc_handleHitPart.sqf
+++ b/addons/shootingrange/functions/fnc_handleHitPart.sqf
@@ -71,7 +71,7 @@ private _hits = _target getVariable [QGVAR(hits), 1];
 private _hit = _target getVariable [QGVAR(hit), 0];
 
 // Exit if target already hit
-if (_hit > _hits) exitWith {};
+if (_hit >= _hits) exitWith {};
 
 // Mark target as hit
 _hit = _hit + 1;

--- a/addons/shootingrange/functions/fnc_handleHitPart.sqf
+++ b/addons/shootingrange/functions/fnc_handleHitPart.sqf
@@ -1,6 +1,7 @@
 /*
  * Author: Jonpas
  * Handles hit part event handler.
+ * Incorporated vanilla handlers from "a3\structures_f\training\data\scripts"
  *
  * Arguments:
  * 0: Target <OBJECT>
@@ -8,7 +9,7 @@
  * 2: Bullet <OBJECT> (Unused)
  * 3: Impact Position (Position, ASL) <ARRAY>
  * 4: Bullet Velocity (Vector) <ARRAY> (Unused)
- * 5: Impact Selections <ARRAY> (Unused)
+ * 5: Impact Selections <ARRAY>
  * 6: Ammo Information <ARRAY> (Unused)
  * 7: Impact Direction (Vector) <ARRAY> (Unused)
  * 8: Impact Radius <NUMBER> (Unused)
@@ -19,18 +20,30 @@
  * None
  *
  * Example:
- * [target, shooter, nil, [0, 0, 0], nil, nil, nil, nil, nil, nil, true] call tac_shootingrange_fnc_handleHitPart;
+ * [target, shooter, nil, [0, 0, 0], nil, ["target"], nil, nil, nil, nil, true] call tac_shootingrange_fnc_handleHitPart;
  *
  * Public: No
  */
 #include "script_component.hpp"
 
-params ["_target", "_shooter", "", "_impactPosition", "", "", "", "", "", "", "_directHit"];
+params ["_target", "_shooter", "", "_impactPosition", "", "_impactSelections", "", "", "", "", "_directHit"];
+
+// Exit if target are is not hit (eg. stand is hit)
+if !("target" in _impactSelections) exitWith {};
 
 private _controller = (_target getVariable [QGVAR(controllers), nil]) select 0;
 
-// Exit if not running
-if !(_controller getVariable [QGVAR(running), false]) exitWith {};
+// Exit if not part of a range or not running
+if (isNil "_controller" || {!(_controller getVariable [QGVAR(running), false])}) exitWith {
+    _target setDamage 0;
+    [_target, 1] call FUNC(animateTarget); // Down
+
+    if ((!isNil "nopop" && nopop) || _target getVariable [QGVAR(stayDown), false]) exitWith {};
+
+    [{
+        [_this, 0] call FUNC(animateTarget); // Up
+    }, _target, 3] call CBA_fnc_waitAndExecute;
+};
 
 private _targets = _target getVariable [QGVAR(targets), []];
 

--- a/addons/shootingrange/functions/fnc_handleHitPart.sqf
+++ b/addons/shootingrange/functions/fnc_handleHitPart.sqf
@@ -79,7 +79,7 @@ _target setVariable [QGVAR(hit), _hit];
 [_controller, "Beep_Target"] call FUNC(playSoundSignal);
 GVAR(score) = GVAR(score) + 1;
 
-if (_hits > 1) then {
+if (_hits > 1 && {_controller getVariable [QGVAR(showHits), true]}) then {
     [[_hit, _hits] joinString "/"] call ACE_Common_fnc_displayTextStructured;
 };
 

--- a/addons/shootingrange/functions/fnc_moduleInit.sqf
+++ b/addons/shootingrange/functions/fnc_moduleInit.sqf
@@ -29,6 +29,9 @@ private _name = _logic getVariable "Name";
 private _targets = [_logic getVariable "Targets", true, true] call ACE_Common_fnc_parseList;
 _targets append (synchronizedObjects _logic);
 
+// Extract hits and convert to numbers
+private _hits = ([_logic getVariable "Hits", true, false] call ACE_Common_fnc_parseList) apply {parseNumber _x};
+
 // Extract invalid target objects and manually check nil (use object if exists, otherwise objNull)
 private _targetsInvalid = [_logic getVariable "TargetsInvalid", true, false] call ACE_Common_fnc_parseList;
 _targetsInvalid = _targetsInvalid apply { [missionNamespace getVariable _x, objNull] select (isNil _x) };
@@ -44,41 +47,25 @@ private _soundSources = [_logic getVariable "SoundSources", true, true] call ACE
 private _mode = _logic getVariable "Mode";
 
 // Extract duration string and convert to numbers
-private _durationsString = [_logic getVariable "Durations", true, false] call ACE_Common_fnc_parseList;
-private _durations = [];
-{
-    _durations pushBack (parseNumber _x);
-} forEach _durationsString;
+private _durations = ([_logic getVariable "Durations", true, false] call ACE_Common_fnc_parseList) apply {parseNumber _x};
 
 // Extract default duration
 private _defaultDuration = _logic getVariable "DefaultDuration";
 
 // Extract target amounts string and convert to numbers
-private _targetAmountsString = [_logic getVariable "TargetAmounts", true, false] call ACE_Common_fnc_parseList;
-private _targetAmounts = [];
-{
-    _targetAmounts pushBack (parseNumber _x);
-} forEach _targetAmountsString;
+private _targetAmounts = ([_logic getVariable "TargetAmounts", true, false] call ACE_Common_fnc_parseList) apply {parseNumber _x};
 
 // Extract default target amount
 private _defaultTargetAmount = _logic getVariable "DefaultTargetAmount";
 
 // Extract pause duration string and convert to numbers
-private _pauseDurationsString = [_logic getVariable "PauseDurations", true, false] call ACE_Common_fnc_parseList;
-private _pauseDurations = [];
-{
-    _pauseDurations pushBack (parseNumber _x);
-} forEach _pauseDurationsString;
+private _pauseDurations = ([_logic getVariable "PauseDurations", true, false] call ACE_Common_fnc_parseList) apply {parseNumber _x};
 
 // Extract default pause duration
 private _defaultPauseDuration = _logic getVariable "DefaultPauseDuration";
 
 // Extract countdown times
-private _countdownTimesString = [_logic getVariable "CountdownTimes", true, false] call ACE_Common_fnc_parseList;
-private _countdownTimes = [];
-{
-    _countdownTimes pushBack (parseNumber _x);
-} forEach _countdownTimesString;
+private _countdownTimes = ([_logic getVariable "CountdownTimes", true, false] call ACE_Common_fnc_parseList) apply {parseNumber _x};
 
 // Extract default countdown time
 private _defaultCountdownTime = _logic getVariable "DefaultCountdownTime";
@@ -91,6 +78,6 @@ private _popOnTriggerExit = _logic getVariable "PopOnTriggerExit";
 
 
 // Prepare with actions
-[_name, _targets, _controllers, _mode, _durations, _defaultDuration, _targetAmounts, _defaultTargetAmount, _pauseDurations, _defaultPauseDuration, _countdownTimes, _defaultCountdownTime, _triggerMarkers, _popOnTriggerExit, _targetsInvalid, _soundSources] call FUNC(create);
+[_name, _targets, _hits, _controllers, _mode, _durations, _defaultDuration, _targetAmounts, _defaultTargetAmount, _pauseDurations, _defaultPauseDuration, _countdownTimes, _defaultCountdownTime, _triggerMarkers, _popOnTriggerExit, _targetsInvalid, _soundSources] call FUNC(create);
 
 ACE_LOGINFO("Shooting Range Module Initialized");

--- a/addons/shootingrange/functions/fnc_moduleInit.sqf
+++ b/addons/shootingrange/functions/fnc_moduleInit.sqf
@@ -76,8 +76,11 @@ private _triggerMarkers = [_logic getVariable "TriggerMarkers", true, false] cal
 // Extract pop targets down on trigger exit setting
 private _popOnTriggerExit = _logic getVariable "PopOnTriggerExit";
 
+// Extract show hits setting
+private _showHits = _logic getVariable "ShowHits";
+
 
 // Prepare with actions
-[_name, _targets, _hits, _controllers, _mode, _durations, _defaultDuration, _targetAmounts, _defaultTargetAmount, _pauseDurations, _defaultPauseDuration, _countdownTimes, _defaultCountdownTime, _triggerMarkers, _popOnTriggerExit, _targetsInvalid, _soundSources] call FUNC(create);
+[_name, _targets, _controllers, _mode, _durations, _defaultDuration, _targetAmounts, _defaultTargetAmount, _pauseDurations, _defaultPauseDuration, _countdownTimes, _defaultCountdownTime, _triggerMarkers, _popOnTriggerExit, _targetsInvalid, _soundSources, _hits, _showHits] call FUNC(create);
 
 ACE_LOGINFO("Shooting Range Module Initialized");

--- a/addons/shootingrange/functions/fnc_popupPFH.sqf
+++ b/addons/shootingrange/functions/fnc_popupPFH.sqf
@@ -39,7 +39,7 @@ private _currentTime = diag_tickTime;
 
 // Remove when time limit (duration) reached - success
 if (_mode in [1, 2, 5] && {_currentTime >= _timeStart + _duration}) exitWith {
-    [_idPFH, _controller, _controllers, _name, _targets, _targetsInvalid, _mode, true, GVAR(targetNumber), GVAR(maxScore)] call FUNC(popupPFHexit);
+    [_idPFH, _controller, _controllers, _name, _targets, _targetsInvalid, _mode, true, GVAR(score), GVAR(maxScore)] call FUNC(popupPFHexit);
 };
 
 // Remove when all targets hit - success
@@ -50,7 +50,7 @@ if ((_mode == 3 && {GVAR(targetNumber) >= _targetAmount}) || {_mode > 3 && {GVAR
     _timeElapsed = format ["%1.%2", _timeElapsed select 0, (_timeElapsed select 1) select [0, TIME_ROUND_CHARS]];
     _timeElapsed = parseNumber _timeElapsed;
 
-    [_idPFH, _controller, _controllers, _name, _targets, _targetsInvalid, _mode, true, GVAR(targetNumber), GVAR(maxScore), _timeElapsed, _triggers] call FUNC(popupPFHexit);
+    [_idPFH, _controller, _controllers, _name, _targets, _targetsInvalid, _mode, true, GVAR(score), GVAR(maxScore), _timeElapsed, _triggers] call FUNC(popupPFHexit);
 };
 
 // Handle automatic target pop-ups in time-based mode
@@ -71,7 +71,7 @@ if (_mode == 1 && {GVAR(lastPauseTime) + _pauseDuration <= _currentTime}) exitWi
     [GVAR(nextTarget), 0] call FUNC(animateTarget); // Up
 
     // Mark target as not yet hit
-    GVAR(nextTarget) setVariable [QGVAR(alreadyHit), false];
+    GVAR(nextTarget) setVariable [QGVAR(hit), 0];
 
     TRACE_2("Targets",GVAR(targetUp),GVAR(nextTarget));
 
@@ -88,5 +88,6 @@ if (_mode in [2, 3] && {GVAR(firstRun)}) exitWith {
     GVAR(targetUp) = selectRandom _targets;
 
     // Animate new target
+    _target setDamage 0;
     [GVAR(targetUp), 0] call FUNC(animateTarget); // Up
 };

--- a/addons/shootingrange/functions/fnc_popupPFHexit.sqf
+++ b/addons/shootingrange/functions/fnc_popupPFHexit.sqf
@@ -36,6 +36,7 @@ params ["_idPFH", "_controller", "_controllers", "_name", "_targets", "_targetsI
 
 // Cleanup variables
 GVAR(targetNumber) = nil;
+GVAR(score) = nil;
 GVAR(maxScore) = nil;
 GVAR(firstRun) = nil;
 GVAR(nextTarget) = nil;

--- a/addons/shootingrange/functions/fnc_popupPFHexit.sqf
+++ b/addons/shootingrange/functions/fnc_popupPFHexit.sqf
@@ -31,9 +31,6 @@ params ["_idPFH", "_controller", "_controllers", "_name", "_targets", "_targetsI
 // Remove PFH
 [_idPFH] call CBA_fnc_removePerFrameHandler;
 
-// Enable automatic pop-ups
-nopop = false;
-
 // Finish or Stop
 [_controller, _controllers, _name, _targets, _targetsInvalid, _success, _score, _maxScore, _timeElapsed] call FUNC(stop);
 

--- a/addons/shootingrange/functions/fnc_start.sqf
+++ b/addons/shootingrange/functions/fnc_start.sqf
@@ -152,14 +152,14 @@ if (_mode > 1) then {
     private _timeStart = diag_tickTime;
     GVAR(firstRun) = true;
 
-        {
-            _x setVariable [QGVAR(stayDown), true, true]; // Disable automatic pop-ups
+    {
+        _x setVariable [QGVAR(stayDown), true, true]; // Disable automatic pop-ups
 
-            // Pop up all targets in Rampage mode
-            if (_mode == 5) then {
-                [_x, 0] call FUNC(animateTarget); // Up
-            };
-        } forEach (_targets + _targetsInvalid);
+        // Pop up all targets in Rampage mode
+        if (_mode == 5) then {
+            [_x, 0] call FUNC(animateTarget); // Up
+        };
+    } forEach (_targets + _targetsInvalid);
 
     // Start PFH
     [FUNC(popupPFH), 0, [_timeStart, _duration, _pauseDuration, _targetAmount, _targets, _targetsInvalid, _controller, _controllers, _name, _mode, _triggers]] call CBA_fnc_addPerFrameHandler;

--- a/addons/shootingrange/functions/fnc_start.sqf
+++ b/addons/shootingrange/functions/fnc_start.sqf
@@ -150,15 +150,14 @@ if (_mode > 1) then {
     private _timeStart = diag_tickTime;
     GVAR(firstRun) = true;
 
-    // Disable automatic pop-ups
-    nopop = true;
-
-    // Pop up all targets in Rampage mode
-    if (_mode == 5) then {
         {
-            [_x, 0] call FUNC(animateTarget); // Up
+            _x setVariable [QGVAR(stayDown), true, true]; // Disable automatic pop-ups
+
+            // Pop up all targets in Rampage mode
+            if (_mode == 5) then {
+                [_x, 0] call FUNC(animateTarget); // Up
+            };
         } forEach (_targets + _targetsInvalid);
-    };
 
     // Start PFH
     [FUNC(popupPFH), 0, [_timeStart, _duration, _pauseDuration, _targetAmount, _targets, _targetsInvalid, _controller, _controllers, _name, _mode, _triggers]] call CBA_fnc_addPerFrameHandler;

--- a/addons/shootingrange/functions/fnc_start.sqf
+++ b/addons/shootingrange/functions/fnc_start.sqf
@@ -31,6 +31,7 @@ if (isNil "_duration" || {isNil "_targetAmount"} || {isNil "_pauseDuration"} || 
 
 // Prepare targets
 {
+    _x setDamage 0;
     [_x, 1] call FUNC(animateTarget); // Down
 } forEach (_targets + _targetsInvalid);
 
@@ -90,6 +91,7 @@ _text = format ["%1<br/><br/>%2: %3", _text, localize LSTRING(By), _playerName];
 
 // Prepare variables
 GVAR(targetNumber) = 0;
+GVAR(score) = 0;
 GVAR(maxScore) = [0, count _targets] select (_mode == 5);
 GVAR(invalidTargetHit) = false;
 

--- a/addons/shootingrange/functions/fnc_stop.sqf
+++ b/addons/shootingrange/functions/fnc_stop.sqf
@@ -29,6 +29,7 @@ params ["_controller", "_controllers", "_name", "_targets", "_targetsInvalid", [
 {
     [_x, 0] call FUNC(animateTarget); // Up
     _x setVariable [QGVAR(alreadyHit), nil];
+    _x setVariable [QGVAR(stayDown), false, true]; // Enable automatic pop-ups
 } forEach (_targets + _targetsInvalid);
 
 // Set variables

--- a/addons/shootingrange/functions/fnc_stop.sqf
+++ b/addons/shootingrange/functions/fnc_stop.sqf
@@ -27,8 +27,9 @@ params ["_controller", "_controllers", "_name", "_targets", "_targetsInvalid", [
 
 // Set targets to original
 {
+    _x setDamage 0;
     [_x, 0] call FUNC(animateTarget); // Up
-    _x setVariable [QGVAR(alreadyHit), nil];
+    _x setVariable [QGVAR(hit), nil];
     _x setVariable [QGVAR(stayDown), false, true]; // Enable automatic pop-ups
 } forEach (_targets + _targetsInvalid);
 

--- a/addons/shootingrange/functions/fnc_triggerPopup.sqf
+++ b/addons/shootingrange/functions/fnc_triggerPopup.sqf
@@ -26,7 +26,7 @@ if (_targetGroup isEqualTo []) exitWith { ACE_LOGERROR("Target Group empty!"); }
 {
     [_x, _state] call FUNC(animateTarget);
 
-    // Mark target as not yet hit
-    private _alreadyHit = [true, false] select (_state == 0);
-    _x setVariable [QGVAR(alreadyHit), _alreadyHit];
+    // Mark target hit
+    private _hits = [_x getVariable [QGVAR(hits), 1], 0] select (_state == 0);
+    _x setVariable [QGVAR(hit), _hits];
 } forEach (_targetGroup + _targetInvalidGroup);

--- a/addons/shootingrange/script_component.hpp
+++ b/addons/shootingrange/script_component.hpp
@@ -1,9 +1,9 @@
 #define COMPONENT shootingrange
 #include "\x\tac\addons\main\script_mod.hpp"
 
-#define DEBUG_MODE_FULL
-#define DISABLE_COMPILE_CACHE
-#define CBA_DEBUG_SYNCHRONOUS
+// #define DEBUG_MODE_FULL
+// #define DISABLE_COMPILE_CACHE
+// #define CBA_DEBUG_SYNCHRONOUS
 // #define ENABLE_PERFORMANCE_COUNTERS
 
 #ifdef DEBUG_ENABLED_SHOOTINGRANGE
@@ -33,6 +33,9 @@
 #define COUNTDOWNTIME_LOWEST 5
 
 #define POPONTRIGGEREXIT_DEFAULT true
+
+#define HITS_DEFAULT [1]
+#define SHOWHITS_DEFAULT true
 
 
 #define NOTIFY_DISTANCE 50

--- a/addons/shootingrange/script_component.hpp
+++ b/addons/shootingrange/script_component.hpp
@@ -1,9 +1,9 @@
 #define COMPONENT shootingrange
 #include "\x\tac\addons\main\script_mod.hpp"
 
-// #define DEBUG_MODE_FULL
-// #define DISABLE_COMPILE_CACHE
-// #define CBA_DEBUG_SYNCHRONOUS
+#define DEBUG_MODE_FULL
+#define DISABLE_COMPILE_CACHE
+#define CBA_DEBUG_SYNCHRONOUS
 // #define ENABLE_PERFORMANCE_COUNTERS
 
 #ifdef DEBUG_ENABLED_SHOOTINGRANGE

--- a/addons/shootingrange/stringtable.xml
+++ b/addons/shootingrange/stringtable.xml
@@ -25,6 +25,12 @@
             <English>List of object names used as targets, separated by commas. Can be synchronized objects.</English>
             <German>Liste der Objektnamen, die als Ziele benutzt werden. Durch Kommas trennen. Die Objekte können synchronisiert sein.</German>
         </Key>
+        <Key ID="STR_TAC_ShootingRange_Hits">
+            <English>Hits</English>
+        </Key>
+        <Key ID="STR_TAC_ShootingRange_HitsDesc">
+            <English>List of numbers used as hits the target takes before falling, separated by commas.</English>
+        </Key>
         <Key ID="STR_TAC_ShootingRange_TargetsInvalid">
             <English>Invalid Targets</English>
         </Key>

--- a/addons/shootingrange/stringtable.xml
+++ b/addons/shootingrange/stringtable.xml
@@ -135,6 +135,12 @@
         <Key ID="STR_TAC_ShootingRange_PopOnTriggerExitDesc">
             <English>Pop targets down when exiting the trigger. Available in Trigger Mode only.</English>
         </Key>
+        <Key ID="STR_TAC_ShootingRange_ShowHits">
+            <English>Show Hits</English>
+        </Key>
+        <Key ID="STR_TAC_ShootingRange_ShowHitsDesc">
+            <English>Show number of hits out of number of hits necessary on each hit. Available only when more than 1 hit is necessary.</English>
+        </Key>
         <Key ID="STR_TAC_ShootingRange_Timed">
             <English>Timed</English>
             <German>Auf Zeit</German>


### PR DESCRIPTION
**When merged this pull request will:**
- Close #103 
- Fix trigger activation during countdown
- Fix config check
- Replace vanilla `hitPart` function with `handleHitPart`
- Remove usage of `nopop` and use custom variable (possible due to custom `hitPart` handling)
- Revert animation changes to work without delays (possible due to custom `hitPart` handling and actually caused issues)
- Add setting for number of hits necessary per target
- Add setting for showing hitshint (number of hits out of number of hits necessary for target to pop down)
- Use `apply` in module init