### PR TITLE
Fix insignia not applying

### DIFF
--- a/addons/insignia/functions/fnc_setInsignia.sqf
+++ b/addons/insignia/functions/fnc_setInsignia.sqf
@@ -17,9 +17,10 @@
 
 params ["_unit"];
 
+// Don't exit if insignia already set, BIS_fnc_getUnitInsignia will return the last set insignia even if it's currently not visible
+if (!local _unit || {_unit != player}) exitWith {};
+
 private _insignia = _unit getVariable [QGVAR(activeInsignia), QGVAR(logoStitch)];
-
-if (!local _unit || {_unit != player} || {_insignia == [_unit] call BIS_fnc_getUnitInsignia}) exitWith {};
-
 [_unit, _insignia] call BIS_fnc_setUnitInsignia;
+
 TRACE_2("Insignia added",_unit,_insignia);


### PR DESCRIPTION
**When merged this pull request will:**
- Fix insignia not applying except in init.
- `BIS_fnc_getUnitInsignia` actually returns whatever was set with `BIS_fnc_setUnitInsignia` instead of what is currently visible.