### PR TITLE
Add MELB (co)pilot ejection and ACE3 fastroping optionals

### DIFF
--- a/optionals/melb_ace_fastroping/$PBOPREFIX$
+++ b/optionals/melb_ace_fastroping/$PBOPREFIX$
@@ -1,0 +1,1 @@
+x\tac\addons\melb_ace_fastroping

--- a/optionals/melb_ace_fastroping/CfgVehicles.hpp
+++ b/optionals/melb_ace_fastroping/CfgVehicles.hpp
@@ -1,0 +1,7 @@
+class CfgVehicles {
+    class MELB_base;
+    class MELB_MH6M: MELB_base {
+        ace_fastroping_enabled = 1;
+        ace_fastroping_ropeOrigins[] = {{-1.17, 0.8, -0.09}, {1.17, 0.8, -0.09}};
+    };
+};

--- a/optionals/melb_ace_fastroping/README.md
+++ b/optionals/melb_ace_fastroping/README.md
@@ -1,0 +1,7 @@
+# About
+
+Adds [ACE3 Fastroping](http://ace3mod.com/wiki/feature/fastroping.html) support to helicopters from [[MELB] Mission Enhanced Little Bird](https://forums.bistudio.com/topic/181895-melb-mission-enhanced-little-bird/) mod by Diesel5187 & sykoCrazy.
+
+### Authors
+
+- [Jonpas](http://github.com/jonpas)

--- a/optionals/melb_ace_fastroping/config.cpp
+++ b/optionals/melb_ace_fastroping/config.cpp
@@ -1,0 +1,16 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"tac_main", "MELB", "ace_fastroping"};
+        author = ECSTRING(main,Author);
+        authors[] = {"Jonpas"};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgVehicles.hpp"

--- a/optionals/melb_ace_fastroping/script_component.hpp
+++ b/optionals/melb_ace_fastroping/script_component.hpp
@@ -1,0 +1,5 @@
+#define COMPONENT melb_ace_fastroping
+
+#include "\x\tac\addons\main\script_mod.hpp"
+
+#include "\x\tac\addons\main\script_macros.hpp"

--- a/optionals/melb_eject/$PBOPREFIX$
+++ b/optionals/melb_eject/$PBOPREFIX$
@@ -1,0 +1,1 @@
+x\tac\addons\melb_eject

--- a/optionals/melb_eject/CfgVehicles.hpp
+++ b/optionals/melb_eject/CfgVehicles.hpp
@@ -1,0 +1,22 @@
+class CfgVehicles {
+    class Helicopter;
+    class Helicopter_Base_F: Helicopter {
+        class Turrets;
+    };
+
+    class Helicopter_Base_H: Helicopter_Base_F {
+        class Turrets: Turrets {
+            class CopilotTurret;
+        };
+    };
+
+    class MELB_base: Helicopter_Base_H {
+        driverCanEject = 1;
+
+        class Turrets: Turrets {
+            class CopilotTurret: CopilotTurret {
+                canEject = 1;
+            };
+        };
+    };
+};

--- a/optionals/melb_eject/README.md
+++ b/optionals/melb_eject/README.md
@@ -1,0 +1,7 @@
+# About
+
+Allows ejection from all seats in helicopters from [[MELB] Mission Enhanced Little Bird](https://forums.bistudio.com/topic/181895-melb-mission-enhanced-little-bird/) mod by Diesel5187 & sykoCrazy.
+
+### Authors
+
+- [Jonpas](http://github.com/jonpas)

--- a/optionals/melb_eject/config.cpp
+++ b/optionals/melb_eject/config.cpp
@@ -1,0 +1,16 @@
+#include "script_component.hpp"
+
+class CfgPatches {
+    class ADDON {
+        units[] = {};
+        weapons[] = {};
+        requiredVersion = REQUIRED_VERSION;
+        requiredAddons[] = {"tac_main", "MELB"};
+        author = ECSTRING(main,Author);
+        authors[] = {"Jonpas"};
+        url = ECSTRING(main,URL);
+        VERSION_CONFIG;
+    };
+};
+
+#include "CfgVehicles.hpp"

--- a/optionals/melb_eject/script_component.hpp
+++ b/optionals/melb_eject/script_component.hpp
@@ -1,0 +1,5 @@
+#define COMPONENT melb_eject
+
+#include "\x\tac\addons\main\script_mod.hpp"
+
+#include "\x\tac\addons\main\script_macros.hpp"


### PR DESCRIPTION
**When merged this pull request will:**
- Allow ejection from MELB's copilot and pilot seats - close #220.
- Add ACE3 Fastroping support to MELB MH6 - close #218.