### PR TITLE
Log shooting range results to RPT

### DIFF
--- a/addons/shootingrange/CfgEventHandlers.hpp
+++ b/addons/shootingrange/CfgEventHandlers.hpp
@@ -12,6 +12,6 @@ class Extended_PreInit_EventHandlers {
 
 class Extended_PostInit_EventHandlers {
     class ADDON {
-        clientInit = QUOTE(call COMPILE_FILE(XEH_postInitClient));
+        init = QUOTE(call COMPILE_FILE(XEH_postInit));
     };
 };

--- a/addons/shootingrange/XEH_postInit.sqf
+++ b/addons/shootingrange/XEH_postInit.sqf
@@ -1,0 +1,14 @@
+#include "script_component.hpp"
+
+if (isServer) then {
+    [QGVAR(logResult), {
+        INFO_1("%1",_this);
+    }] call CBA_fnc_addEventHandler;
+};
+
+// Exit on Server and Headless Client
+if (!hasInterface) exitWith {};
+
+[QGVAR(playSignal), {
+    (_this select 0) say3D [_this select 1, _this select 2];
+}] call CBA_fnc_addEventHandler;

--- a/addons/shootingrange/XEH_postInitClient.sqf
+++ b/addons/shootingrange/XEH_postInitClient.sqf
@@ -1,5 +1,0 @@
-#include "script_component.hpp"
-
-[QGVAR(playSignal), {
-    (_this select 0) say3D [_this select 1, _this select 2];
-}] call CBA_fnc_addEventHandler;

--- a/addons/shootingrange/functions/fnc_stop.sqf
+++ b/addons/shootingrange/functions/fnc_stop.sqf
@@ -65,6 +65,14 @@ if (_success) then {
 
     _text = format ["%1<br/><br/>%2: %3", _text, localize LSTRING(By), _playerName];
     [_text, _size + 1, false] call FUNC(notifyVicinity);
+
+    // Print result to server and client RPT
+    _text = [_text, "<br/><br/>", ". "] call CBA_fnc_replace; // Remove double newlines first
+    _text = [_text, "<br/>", ". "] call CBA_fnc_replace;
+    [QGVAR(logResult), _text] call CBA_fnc_serverEvent;
+    if (!isServer) then {
+        INFO_1("%1",_text);
+    };
 } else {
     private _text = format ["%1<br/>%2", localize LSTRING(Range), _name];
     if (GVAR(invalidTargetHit)) then {


### PR DESCRIPTION
**When merged this pull request will:**
- Close #214 
- Log result on successful shooting range completion on server and the client who finished it.

Example:
```
1:29:52 [TAC] (shootingrange) INFO: Shooting Range (Oval Test) Finished. Accuracy: 94% (15/16). Time Elapsed: 3.917s. By: Dev
```