### PR TITLE
Remove multiple hit from shooting range

### DIFF
--- a/addons/shootingrange/CfgVehicles.hpp
+++ b/addons/shootingrange/CfgVehicles.hpp
@@ -23,12 +23,6 @@ class CfgVehicles {
                 typeName = "STRING";
                 defaultValue = "";
             };
-            class Hits {
-                displayName = CSTRING(Hits);
-                description = CSTRING(HitsDesc);
-                typeName = "STRING";
-                defaultValue = "";
-            };
             class TargetsInvalid {
                 displayName = CSTRING(TargetsInvalid);
                 description = CSTRING(TargetsInvalidDesc);
@@ -132,12 +126,6 @@ class CfgVehicles {
             class PopOnTriggerExit {
                 displayName = CSTRING(PopOnTriggerExit);
                 description = CSTRING(PopOnTriggerExitDesc);
-                typeName = "BOOL";
-                defaultValue = 1;
-            };
-            class ShowHits {
-                displayName = CSTRING(ShowHits);
-                description = CSTRING(ShowHitsDesc);
                 typeName = "BOOL";
                 defaultValue = 1;
             };

--- a/addons/shootingrange/functions/fnc_create.sqf
+++ b/addons/shootingrange/functions/fnc_create.sqf
@@ -17,14 +17,14 @@
  * 11: Pop on Trigger Exit <BOOL> (default: true)
  * 12: Invalid Targets <ARRAY> (default: [])
  * 13: Sound Sources <ARRAY> (default: [])
- * 14: Hits <ARRAY> (default: [])
- * 15: Show Hits <BOOL>
+ * 14: Deprecated - used to be: Hits <ARRAY> (default: [1])
+ * 15: Deprecated - used to be: Show Hits <BOOL> (default: true)
  *
  * Return Value:
  * None
  *
  * Example:
- * ["range", [target1, target2], [controller1, controller2], 1, [30, 60], 60,  [3, 5], 5, 10, [marker1, marker2], [2, 2], true] call tac_shootingrange_fnc_create;
+ * ["range", [target1, target2], [controller1, controller2], 1, [30, 60], 60,  [3, 5], 5, 10, [marker1, marker2], nil, nil] call tac_shootingrange_fnc_create;
  *
  * Public: Yes
  */
@@ -47,17 +47,13 @@ params [
     ["_popOnTriggerExit", POPONTRIGGEREXIT_DEFAULT, [true] ],
     ["_targetsInvalid", [], [[]] ],
     ["_soundSources", [], [[]] ],
-    ["_hits", HITS_DEFAULT, [[]] ],
-    ["_showHits", SHOWHITS_DEFAULT, [true] ]
+    "", // deprecated - backwards compatibility
+    "" // deprecated - backwards compatibility
 ];
 
 // Verify data
 if (_targets isEqualTo [] || {_controllers isEqualTo []}) exitWith {
     ERROR_1("Targets and Controllers fields/arguments must NOT be empty! (%1)",_name);
-};
-
-if ((count _hits > 1 && count _hits < count _targets) || {count _hits > count _targets}) exitWith {
-    ERROR_1("Hits field/argument must have exactly 1 element ot equal elements as Targets fields/arguments! (%1)",_name);
 };
 
 if (_mode == 4 && {count _triggerMarkers != count _targets}) exitWith {
@@ -87,12 +83,6 @@ if (_durations isEqualTo []) then {
     _durations = DURATIONS_DEFAULT;
 } else {
     _durations pushBack 0; // Add infinite duration
-};
-
-if (count _hits < 2) then {
-    {
-        _hits pushBack ([_hits select 0, 1] select (_hits isEqualTo []));
-    } forEach _targets;
 };
 
 if (_targetAmounts isEqualTo []) then {
@@ -147,7 +137,6 @@ _countdownTimes sort true;
         _x setVariable [QGVAR(mode), _mode, true];
     };
     _x setVariable [QGVAR(soundSources), _controllers + _soundSources];
-    _x setVariable [QGVAR(showHits), _showHits];
 
     // Main
     private _actionRange = [
@@ -357,8 +346,4 @@ if (_mode == 4) then {
     _x setVariable [QGVAR(targets), _targets];
     _x setVariable [QGVAR(controllers), _controllers];
     _x setVariable [QGVAR(triggers), _triggers];
-
-    if (_x in _targets) then {
-        _x setVariable [QGVAR(hits), _hits select _forEachIndex];
-    };
 } forEach (_targets + _targetsInvalid);

--- a/addons/shootingrange/functions/fnc_handleHitPart.sqf
+++ b/addons/shootingrange/functions/fnc_handleHitPart.sqf
@@ -1,7 +1,7 @@
 /*
  * Author: Jonpas
  * Handles hit part event handler.
- * Incorporated vanilla handlers from "a3\structures_f\training\data\scripts"
+ * Incorporated vanilla handlers from "a3\structures_f\training\data\scripts".
  *
  * Arguments:
  * 0: Target <OBJECT>
@@ -70,27 +70,10 @@ if (_shooter != _starter) exitWith {
 };
 
 
-private _hits = _target getVariable [QGVAR(hits), 1];
-private _hit = _target getVariable [QGVAR(hit), 0];
-
-// Exit if target already hit
-if (_hit >= _hits) exitWith {};
-
 // Mark target as hit
-_hit = _hit + 1;
-_target setVariable [QGVAR(hit), _hit];
+_target setVariable [QGVAR(hit), true]; // For trigger popup
 [_controller, "Beep_Target"] call FUNC(playSoundSignal);
 GVAR(score) = GVAR(score) + 1;
-
-if (_hits > 1 && {_controller getVariable [QGVAR(showHits), true]}) then {
-    [[_hit, _hits] joinString "/"] call ACE_Common_fnc_displayTextStructured;
-};
-
-TRACE_2("Hit",_hits,_hit);
-
-// Exit if not enough hits yet
-if (_hit < _hits) exitWith {};
-
 [_target, 1] call FUNC(animateTarget); // Down
 
 // Set next target
@@ -104,7 +87,7 @@ if (_mode == 2 || {_mode == 3 && {GVAR(targetNumber) < _controller getVariable [
     GVAR(nextTarget) = selectRandom (_targets - [_target]);
 
     // Mark target as not yet hit
-    GVAR(nextTarget) setVariable [QGVAR(hit), 0];
+    GVAR(nextTarget) setVariable [QGVAR(hit), false];
 
     // Animate target
     _target setDamage 0;

--- a/addons/shootingrange/functions/fnc_moduleInit.sqf
+++ b/addons/shootingrange/functions/fnc_moduleInit.sqf
@@ -29,9 +29,6 @@ private _name = _logic getVariable "Name";
 private _targets = [_logic getVariable "Targets", true, true] call ACE_Common_fnc_parseList;
 _targets append (synchronizedObjects _logic);
 
-// Extract hits and convert to numbers
-private _hits = ([_logic getVariable "Hits", true, false] call ACE_Common_fnc_parseList) apply {parseNumber _x};
-
 // Extract invalid target objects and manually check nil (use object if exists, otherwise objNull)
 private _targetsInvalid = [_logic getVariable "TargetsInvalid", true, false] call ACE_Common_fnc_parseList;
 _targetsInvalid = _targetsInvalid apply { [missionNamespace getVariable _x, objNull] select (isNil _x) };
@@ -76,11 +73,8 @@ private _triggerMarkers = [_logic getVariable "TriggerMarkers", true, false] cal
 // Extract pop targets down on trigger exit setting
 private _popOnTriggerExit = _logic getVariable "PopOnTriggerExit";
 
-// Extract show hits setting
-private _showHits = _logic getVariable "ShowHits";
-
 
 // Prepare with actions
-[_name, _targets, _controllers, _mode, _durations, _defaultDuration, _targetAmounts, _defaultTargetAmount, _pauseDurations, _defaultPauseDuration, _countdownTimes, _defaultCountdownTime, _triggerMarkers, _popOnTriggerExit, _targetsInvalid, _soundSources, _hits, _showHits] call FUNC(create);
+[_name, _targets, _controllers, _mode, _durations, _defaultDuration, _targetAmounts, _defaultTargetAmount, _pauseDurations, _defaultPauseDuration, _countdownTimes, _defaultCountdownTime, _triggerMarkers, _popOnTriggerExit, _targetsInvalid, _soundSources] call FUNC(create);
 
 INFO_1("Shooting Range Module Initialized (%1)",_name);

--- a/addons/shootingrange/functions/fnc_popupPFH.sqf
+++ b/addons/shootingrange/functions/fnc_popupPFH.sqf
@@ -71,7 +71,7 @@ if (_mode == 1 && {GVAR(lastPauseTime) + _pauseDuration <= _currentTime}) exitWi
     [GVAR(nextTarget), 0] call FUNC(animateTarget); // Up
 
     // Mark target as not yet hit
-    GVAR(nextTarget) setVariable [QGVAR(hit), 0];
+    GVAR(nextTarget) setVariable [QGVAR(hit), false];
 
     TRACE_2("Targets",GVAR(targetUp),GVAR(nextTarget));
 

--- a/addons/shootingrange/functions/fnc_triggerPopup.sqf
+++ b/addons/shootingrange/functions/fnc_triggerPopup.sqf
@@ -24,7 +24,7 @@ if (_targetGroup isEqualTo []) exitWith { ERROR("Target Group empty!"); };
 
 {
     // Animate only targets that haven't been cleared yet
-    if (_x getVariable [QGVAR(hit), 0] < _x getVariable [QGVAR(hits), 1]) then {
+    if !(_x getVariable [QGVAR(hit), false]) then {
         [_x, _state] call FUNC(animateTarget);
     };
 } forEach _targetGroup;

--- a/addons/shootingrange/script_component.hpp
+++ b/addons/shootingrange/script_component.hpp
@@ -34,8 +34,6 @@
 
 #define POPONTRIGGEREXIT_DEFAULT true
 
-#define HITS_DEFAULT [1]
-#define SHOWHITS_DEFAULT true
 
 #define NOTIFY_DISTANCE 10
 

--- a/addons/shootingrange/stringtable.xml
+++ b/addons/shootingrange/stringtable.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project name="TAC">
     <Package name="ShootingRange">
         <Key ID="STR_TAC_ShootingRange_Range">
@@ -25,13 +25,6 @@
             <English>List of object names used as targets, separated by commas. Can be synchronized objects.</English>
             <German>Liste der Objektnamen, die als Ziele benutzt werden. Durch Kommas trennen. Die Objekte können synchronisiert sein.</German>
         </Key>
-        <Key ID="STR_TAC_ShootingRange_Hits">
-            <English>Hits</English>
-            <German>Treffer</German>
-        </Key>
-        <Key ID="STR_TAC_ShootingRange_HitsDesc">
-            <English>List of numbers used as hits the target takes before falling, separated by commas.</English>
-            <German>Liste der Nummern, die genutzt werden, um die zum Umfallen eines Zieles benötigte Anzahl an Treffern festzulegen. Durch Kommas trennen.</German>
         </Key>
         <Key ID="STR_TAC_ShootingRange_TargetsInvalid">
             <English>Invalid Targets</English>
@@ -144,14 +137,6 @@
         <Key ID="STR_TAC_ShootingRange_PopOnTriggerExitDesc">
             <English>Pop targets down when exiting the trigger. Available in Trigger Mode only.</English>
             <German>Klappt Ziele ab, wenn der Auslöserbereich verlassen wird. Nur im Auslöser-Modus verfügbar.</German>
-        </Key>
-        <Key ID="STR_TAC_ShootingRange_ShowHits">
-            <English>Show Hits</English>
-            <German>Zeige Treffer</German>
-        </Key>
-        <Key ID="STR_TAC_ShootingRange_ShowHitsDesc">
-            <English>Show number of hits out of number of hits necessary on each hit. Available only when more than 1 hit is necessary.</English>
-            <German>Zeige pro Treffer die Anzahl an bisherigen Treffern von der insgesamt benötigten Zahl an Treffern. Nur verfügbar wenn mehr als 1 Treffer benötigt wird.</German>
         </Key>
         <Key ID="STR_TAC_ShootingRange_Timed">
             <English>Timed</English>


### PR DESCRIPTION
**When merged this pull request will:**
- Remove multiple hit from shooting range (introduced in #179), as it is no longer used and will not be used (only maintenance and possible bug causer).
- Deprecate `hits` and `showHits` parameters in public `tac_shootingrange_fnc_create` function (by simply leaving empty)
- Maybe fixes weird pop-up, not popping down issues.