### PR TITLE
Remove door opening/closing in Air Security

### DIFF
--- a/addons/air_security/README.md
+++ b/addons/air_security/README.md
@@ -10,7 +10,6 @@ Enables pilots to secure the passengers inside helicopters and planes.
 ### Features
 
 - Ability to Secure and Unsecure Crew in helicopters
-- Plays an open/close door animation for helicopters that support it
 - When Pilot or Copilot is present, Cargo can't Secure themselves
 - Anyone can always Secure or Unsecure from outside
 - When Pilot and Copilot die, anyone can Unsecure

--- a/addons/air_security/functions/fnc_setSecurity.sqf
+++ b/addons/air_security/functions/fnc_setSecurity.sqf
@@ -17,26 +17,10 @@
 
 params ["_vehicle"];
 
-// Doors to be animated @todo change to dynamic
-private _doors = [
-    "door_L","door_R", // UH-80 Ghost Hawk
-    "door_back_L","door_back_R", // CH-49 Mohawk
-    "door_4_source","door_5_source","door_6_source" // Mi-290 Taru (Pods)
-];
-
-private _newDoorStatus = 1;
-
 if (locked _vehicle < 2) then {
     [QGVAR(setLock), [_vehicle, "LOCKED"], _vehicle] call CBA_fnc_targetEvent;
-    _newDoorStatus = 0;
     [localize LSTRING(Secured), QPATHTOF(UI\secure_ca.paa)] call ACEFUNC(common,displayTextPicture);
 } else {
     [QGVAR(setLock), [_vehicle, "UNLOCKED"], _vehicle] call CBA_fnc_targetEvent;
-    _newDoorStatus = 1;
     [localize LSTRING(Unsecured), QPATHTOF(UI\unsecure_ca.paa)] call ACEFUNC(common,displayTextPicture);
 };
-
-// Animate doors
-{
-    _vehicle animateDoor [_x, _newDoorStatus];
-} forEach _doors;

--- a/addons/air_security/functions/fnc_setSecurity.sqf
+++ b/addons/air_security/functions/fnc_setSecurity.sqf
@@ -1,6 +1,6 @@
 /*
  * Author: DaC, Jonpas
- * Closes or opens the vehicle doors and calls lock function on all connected.
+ * Toggles vehicle crew security.
  *
  * Arguments:
  * 0: Vehicle <OBJECT>


### PR DESCRIPTION
**When merged this pull request will:**
- Close #313 

CUP helicopters have actions for doors, ACE3 Fastroping automatically opens and closes doors.